### PR TITLE
fix(site): mobile responsiveness + repo → website discoverability

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # agentcomm
 
+**🌐 Website: [yonidavidson.github.io/agentcomm](https://yonidavidson.github.io/agentcomm/)** — use cases, backends, and a live demo where two agents' conversation [is a git branch](https://github.com/yonidavidson/agentcomm/tree/agentcomm).
+
 A tiny mailbox / message bus for AI agents that shell out to one CLI. Agents
 `register`, `send`, and read their `inbox`; a single `Backend` interface hides
 where the messages actually live. Local runs need **zero dependencies**; cloud

--- a/docs/index.html
+++ b/docs/index.html
@@ -116,7 +116,9 @@
               Zero new infrastructure: if <code>gh</code> is logged in (or
               <code>GITHUB_TOKEN</code> is set), you're done. Poll gently —
               the API quota is shared — and give each consumer its own inbox
-              (no <code>claim</code> here).
+              (no <code>claim</code> here). Proof:
+              <a href="https://github.com/yonidavidson/agentcomm/tree/agentcomm">a real
+              two-agent exchange living as commits on this repo's own bus branch</a>.
             </p>
           </div>
           <div class="usecase-visual">

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -423,6 +423,30 @@ footer a { color: var(--text-dim); }
 footer a:hover { color: var(--text); }
 .footer-links { display: flex; gap: 18px; justify-content: center; margin-bottom: 14px; flex-wrap: wrap; }
 
+/* ---- mobile ---- */
+body { overflow-x: clip; } /* the page never scrolls sideways; wide content scrolls in its own container */
+
+@media (max-width: 720px) {
+  nav.topbar { display: block; text-align: center; padding: 10px 12px; }
+  nav.topbar .brand { justify-content: center; margin-bottom: 6px; }
+  /* Inline flow instead of flex: anchors wrap unconditionally on narrow screens. */
+  nav.topbar .nav-links { display: block; font-size: 0.85rem; line-height: 1.9; }
+  nav.topbar .nav-links a { margin: 0 7px; white-space: nowrap; }
+  .wrap { padding: 0 16px; }
+  section { padding: 56px 0; }
+  .hero { min-height: auto; padding: 64px 16px 48px; }
+  .subhead { margin-bottom: 28px; }
+  .codeblock { max-width: 100%; font-size: 0.78rem; }
+  .section-head { margin-bottom: 34px; }
+  .plugin-panel { padding: 24px 18px; gap: 24px; }
+  .usecase-panel { padding: 22px 16px; gap: 22px; }
+  .usecase-stack { margin-bottom: 36px; }
+  .enterprise-band { padding: 26px 18px; }
+  .enterprise-head h3 { font-size: 1.35rem; }
+  .diagram-box { min-width: 100px; padding: 10px 12px; font-size: 0.76rem; }
+  .uc-code { font-size: 0.72rem; }
+}
+
 @media (prefers-reduced-motion: reduce) {
   html { scroll-behavior: auto; }
 }


### PR DESCRIPTION
Closes #20.

- Phone widths: centered inline-flow nav (wraps unconditionally), hero without the 86vh minimum, phone paddings across sections/panels/enterprise band, scaled diagram boxes and code fonts, `overflow-x: clip` on body — wide tables/code scroll in their own containers, the page never scrolls sideways.
- Verified with **true-viewport** renders (390px iframe technique — bare `--window-size` silently clamps to Chrome's ~500px minimum window width and produces phantom overflow).
- Discoverability: website link at the top of the README, repo homepage + description set via `gh repo edit`, and the github flagship panel links the real two-agent exchange on this repo's own bus branch (#18's living exhibit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)