### PR TITLE
release: 0.4.0 — version bump so plugin installs actually update

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,8 +9,8 @@
     {
       "name": "agentcomm",
       "source": "./",
-      "description": "Multi-agent mailbox CLI (register/send/inbox/peek/wait/broadcast) so Claude can coordinate with other agents or sessions sharing a backend.",
-      "version": "0.3.0",
+      "description": "Multi-agent mailbox CLI — any git remote is a bus (git+ssh/github/sqlite/s3/gcs/postgres). register/send/inbox/wait/claim/log/channels so Claude coordinates with other agents or sessions; auto-selects the repo bus inside a git repo.",
+      "version": "0.4.0",
       "author": {
         "name": "Yoni Davidson"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agentcomm",
-  "description": "Multi-agent mailbox CLI (register/send/inbox/peek/wait/broadcast) so Claude can coordinate with other agents or sessions sharing a backend.",
-  "version": "0.3.0",
+  "description": "Multi-agent mailbox CLI — any git remote is a bus (git+ssh/github/sqlite/s3/gcs/postgres). register/send/inbox/wait/claim/log/channels so Claude coordinates with other agents or sessions; auto-selects the repo bus inside a git repo.",
+  "version": "0.4.0",
   "author": {
     "name": "Yoni Davidson",
     "email": "yonidavidson@tabnine.com"
@@ -9,5 +9,10 @@
   "homepage": "https://github.com/yonidavidson/agentcomm",
   "repository": "https://github.com/yonidavidson/agentcomm",
   "license": "MIT",
-  "keywords": ["multi-agent", "mailbox", "coordination", "cli"]
+  "keywords": [
+    "multi-agent",
+    "mailbox",
+    "coordination",
+    "cli"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentcomm",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "A tiny mailbox/message bus for AI agents that shell out to one CLI. Pluggable storage backends behind a single Backend interface.",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
Manifests said 0.3.0 while main gained the git backend, auto-default, log/conventions/purge and the rewritten skill — so /plugin reported 'already at latest' on stale copies. Bumps plugin.json, marketplace.json, package.json to 0.4.0.