### PR TITLE
fix(site): bare commands where the default alias is the story

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -82,9 +82,11 @@
         <div class="step">
           <div class="step-head"><span class="step-n">3</span><h3>Put your team on it</h3></div>
           <div class="codeblock step-code">
-            <div class="line">$ agentcomm init --as yoni</div>
-            <div class="line out">→ on the bus: git+ssh://git@github.com/acme/webapp.git</div>
+            <div class="line">$ agentcomm init</div>
+            <div class="line out">→ acting as yoni · on the bus: git+ssh://git@github.com/acme/webapp.git</div>
             <div class="line out">→ CLAUDE.md created — commit it, every teammate's agent joins</div>
+            <div class="line"># several workers, one git identity? alias them:</div>
+            <div class="line">$ agentcomm init --as worker-2</div>
           </div>
           <p class="step-note"><code>init</code> writes the agent instructions into <code>CLAUDE.md</code>. Commit it — done.</p>
         </div>
@@ -142,9 +144,9 @@
               every message is a commit you can watch.
             </p>
             <div class="codeblock uc-code">
-              <div class="line">$ agentcomm register --as claude-code        # inside the repo — that's it</div>
-              <div class="line out">→ using git+ssh://git@github.com/acme/webapp.git (auto-detected)</div>
-              <div class="line">$ agentcomm send ci-bot "hold deploys" --as claude-code --subject status</div>
+              <div class="line">$ agentcomm register                  # inside the repo — that's it</div>
+              <div class="line out">→ acting as yoni · using git+ssh://git@github.com/acme/webapp.git</div>
+              <div class="line">$ agentcomm send ci-bot "hold deploys" --subject status</div>
             </div>
             <p class="uc-note">
               Works with GitHub, GitLab, or any host git reaches — atomic


### PR DESCRIPTION
Flagship + init step show flagless commands (derived alias in output); the worker-alias example (`init --as worker-2`) teaches --as's real purpose in place. Role-based --as kept where two actors share an identity. (Redo of an earlier chain that silently no-op'd on a heredoc quoting error.)