### PR TITLE
chore: dogfood agentcomm init — this repo's agents ride its own bus

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,12 @@
+<!-- agentcomm -->
+## Agent coordination (agentcomm)
+
+This repo has a message bus for AI agents. When working here:
+
+- At session start: `agentcomm register --as <descriptive-name>` and check
+  your inbox (`agentcomm inbox --as <name> --json`) — instructions may be
+  waiting. The bus is auto-detected from this repo; `agentcomm describe`
+  explains it, `agentcomm conventions` has the team rules.
+- Coordinate with other agents via `send`/`wait` (subjects: task, ack,
+  done, question, status; reply on the sender's --thread).
+- Always check your inbox before reporting work done.


### PR DESCRIPTION
Verbatim output of a bare `agentcomm init` in this repo (auto-detected `git+ssh` bus, alias derived from git identity — roster already showed 2 agents). Once merged, every AI agent that opens this repo self-onboards onto its bus.