### PR TITLE
docs: examples speak the current dialect (0.7.3)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "agentcomm",
       "source": "./",
       "description": "Multi-agent mailbox CLI — any git remote is a bus (git+ssh/github/sqlite/s3/gcs/postgres). register/send/inbox/wait/claim/log/channels so Claude coordinates with other agents or sessions; auto-selects the repo bus inside a git repo.",
-      "version": "0.7.2",
+      "version": "0.7.3",
       "author": {
         "name": "Yoni Davidson"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agentcomm",
   "description": "Multi-agent mailbox CLI — any git remote is a bus (git+ssh/github/sqlite/s3/gcs/postgres). register/send/inbox/wait/claim/log/channels so Claude coordinates with other agents or sessions; auto-selects the repo bus inside a git repo.",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "author": {
     "name": "Yoni Davidson",
     "email": "yonidavidson@tabnine.com"

--- a/README.md
+++ b/README.md
@@ -62,28 +62,26 @@ defaults to the repo bus, like everywhere else.
 ## Quick start
 
 ```bash
-# in a git repo: one command puts the repo — and, once CLAUDE.md is
-# committed, your whole team's agents — on the bus
-agentcomm init
+# in a git repo: zero config. You're on the repo bus under a session-unique
+# alias; one bare `init` also writes CLAUDE.md so your team's agents join.
+agentcomm init                      # → acting as yoni-3f2a · on the bus: git+ssh://…
+agentcomm agents                    # who's here: yoni-3f2a · dana-97b1 · ci-bot
+agentcomm send ci-bot "hold deploys" --subject status
 
-# or pick a backend explicitly via env (or --backend per call)
-export AGENTCOMM_BACKEND=sqlite:///tmp/bus.db
-
-agentcomm register --as alice
-agentcomm register --as bob
-
-agentcomm send bob "ship it" --as alice --subject plan
-agentcomm inbox --as bob --json        # consumes; archives under read/
-agentcomm peek  --as bob               # non-consuming
-agentcomm wait  --as bob --timeout 30000   # exit 0 on delivery, 2 on timeout
+# named ROLES (addressable, stable) take --as; register warns if the alias
+# is live in another session
+agentcomm register --as reviewer
+agentcomm send reviewer "review src/auth.ts" --subject task --thread auth-1
+agentcomm inbox --as reviewer --json     # consumes; archives under read/
+agentcomm wait  --as reviewer --timeout 30000   # exit 0 on delivery, 2 on timeout
 
 # shared-worker-queue pattern (multiple workers, one queue) — git + SQL backends
-agentcomm send work-queue "task-1" --as producer
+agentcomm send work-queue "task-1" --subject task
 agentcomm claim --queue work-queue --as worker-1   # atomic; null when empty
 
-# distributed (across machines/containers) — real push, not poll
+# other stores when topology calls for it (push wait, SQL claims):
 export AGENTCOMM_BACKEND=postgres://user:pass@host:5432/agentcomm
-agentcomm wait --as bob --timeout 30000   # resolves within ~ms of a send, via LISTEN/NOTIFY
+agentcomm wait --as reviewer --timeout 30000   # resolves within ~ms via LISTEN/NOTIFY
 ```
 
 `send`/`broadcast` read the body from the trailing argument, or from **stdin**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentcomm",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "A tiny mailbox/message bus for AI agents that shell out to one CLI. Pluggable storage backends behind a single Backend interface.",
   "type": "module",
   "license": "MIT",

--- a/skills/agentcomm/SKILL.md
+++ b/skills/agentcomm/SKILL.md
@@ -200,33 +200,37 @@ happens automatically based on `--backend`.
 ## Typical flow
 
 A full handoff between two agents, showing the conventions above
-(`AC` stands in for `node "$CLAUDE_PLUGIN_ROOT/dist/cli.js"`):
+(`AC` stands in for `node "$CLAUDE_PLUGIN_ROOT/dist/cli.js"`). In a shared
+git repo NO backend flags are needed — everyone lands on the repo bus; add
+`--backend <uri>` only for other stores. planner and worker-1 are ROLES
+(addressable by name), so each keeps a stable `--as`:
 
 ```bash
-B="--backend sqlite:///tmp/agentcomm/bus.db"
-
-# each agent registers once
-AC register --as planner $B
-AC register --as worker  $B
+# each role registers once (a warning here means the alias is live elsewhere)
+AC register --as planner
+AC register --as worker-1
 
 # planner verifies the counterpart is really there, then hands off work
-AC agents $B --json                # confirm "worker" appears
-AC send worker "build the auth module" --as planner --subject task --thread auth-1 $B
+AC agents --json                        # confirm "worker-1" appears
+AC send worker-1 "build the auth module" --as planner --subject task --thread auth-1
 
-# worker blocks for work (exit 0 = message, exit 2 = timeout), acks on-thread
-AC wait --as worker --timeout 60000 $B --json
-AC send planner "ack: starting auth module" --as worker --subject ack --thread auth-1 $B
+# worker-1 blocks for work (exit 0 = message, exit 2 = timeout), acks on-thread
+AC wait --as worker-1 --timeout 60000 --json
+AC send planner "ack: starting auth module" --as worker-1 --subject ack --thread auth-1
 
-# ... worker does the work ...
+# ... worker-1 does the work ...
 
-# worker drains its inbox BEFORE reporting done (a correction may have arrived),
-# then closes the loop on the same thread
-AC inbox --as worker $B --json
-AC send planner "done: auth module built, tests green" --as worker --subject done --thread auth-1 $B
+# worker-1 drains its inbox BEFORE reporting done (a correction may have
+# arrived), then closes the loop on the same thread
+AC inbox --as worker-1 --json
+AC send planner "done: auth module built, tests green" --as worker-1 --subject done --thread auth-1
 
 # planner collects the ack + result, correlated by thread=auth-1
-AC inbox --as planner $B --json
+AC inbox --as planner --json
 ```
+
+Working solo (no named role)? Drop every `--as` — bare commands share your
+session alias automatically.
 
 ## Notes
 


### PR DESCRIPTION
Typical flow + Quick start modernized: zero-flag repo-bus default with session aliases, init-first, --as framed as the role convention (planner/worker-1/reviewer), collision warning noted, claim = git+SQL. Solo line: bare commands share the session alias automatically.