### PR TITLE
feat(site): the yellow bus — school-bus palette + a real bus in the hero

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -37,6 +37,40 @@
       In a git repo, agents are <strong>on the network by default</strong> —
       the repo is the bus.
     </p>
+    <div class="hero-bus" aria-hidden="true">
+      <svg viewBox="0 0 760 190">
+        <line x1="10" y1="172" x2="750" y2="172" class="hb-road"/>
+        <line x1="10" y1="172" x2="750" y2="172" class="hb-dash"/>
+        <rect x="150" y="46" width="440" height="98" rx="18" fill="#f2a900" stroke="#1a2330" stroke-width="4"/>
+        <path d="M590 62 h34 a14 14 0 0 1 14 14 v54 a14 14 0 0 1 -14 14 h-34 z" fill="#f2a900" stroke="#1a2330" stroke-width="4"/>
+        <rect x="596" y="66" width="34" height="26" rx="5" fill="#dbe6f2" stroke="#1a2330" stroke-width="3"/>
+        <circle cx="632" cy="128" r="6" fill="#fff3c4" stroke="#1a2330" stroke-width="3"/>
+        <rect x="255" y="28" width="230" height="26" rx="7" fill="#1a2330"/>
+        <text x="370" y="46" text-anchor="middle" font-family="JetBrains Mono, monospace" font-size="15" font-weight="700" fill="#f2a900">→ origin/agentcomm</text>
+        <g stroke="#1a2330" stroke-width="3">
+          <rect x="172" y="64" width="64" height="36" rx="6" fill="#171d26"/>
+          <rect x="248" y="64" width="64" height="36" rx="6" fill="#171d26"/>
+          <rect x="324" y="64" width="64" height="36" rx="6" fill="#171d26"/>
+          <rect x="400" y="64" width="64" height="36" rx="6" fill="#171d26"/>
+          <rect x="476" y="64" width="64" height="36" rx="6" fill="#171d26"/>
+        </g>
+        <g font-family="JetBrains Mono, monospace" font-size="13" font-weight="700" fill="#7fd1a8">
+          <text x="204" y="87" text-anchor="middle">&gt;_</text>
+          <text x="280" y="87" text-anchor="middle">&gt;_</text>
+          <text x="356" y="87" text-anchor="middle">&gt;_</text>
+          <text x="432" y="87" text-anchor="middle">&gt;_</text>
+          <text x="508" y="87" text-anchor="middle">&gt;_</text>
+        </g>
+        <text x="370" y="129" text-anchor="middle" font-family="Space Grotesk, sans-serif" font-size="19" font-weight="700" fill="#1a2330">agentcomm</text>
+        <line x1="158" y1="138" x2="582" y2="138" stroke="#1a2330" stroke-width="3"/>
+        <g>
+          <circle cx="230" cy="152" r="24" fill="#1a2330"/>
+          <circle cx="230" cy="152" r="10" fill="#faf7f2"/>
+          <circle cx="520" cy="152" r="24" fill="#1a2330"/>
+          <circle cx="520" cy="152" r="10" fill="#faf7f2"/>
+        </g>
+      </svg>
+    </div>
     <div class="cta-row">
       <a class="btn btn-primary" href="https://github.com/yonidavidson/agentcomm">View on GitHub</a>
       <a class="btn btn-ghost" href="#plugin">Use as a Claude Code plugin</a>
@@ -135,7 +169,7 @@
       </div>
 
       <div class="usecase-stack">
-        <div class="usecase-panel reveal" style="--uc:#00857c;">
+        <div class="usecase-panel reveal" style="--uc:#f2a900; --uc-text:#1a2330; --uc-strong:#8a6100;">
           <div class="usecase-copy">
             <span class="uc-tag">git</span>
             <h3>The repo is the bus</h3>
@@ -177,7 +211,7 @@
           </div>
         </div>
 
-        <div class="usecase-panel reveal" style="--uc:#2e9e44;">
+        <div class="usecase-panel reveal" style="--uc:#0e7c9c;">
           <div class="usecase-copy">
             <span class="uc-tag">ci/cd</span>
             <h3>Ask your pipeline how it's going</h3>
@@ -273,7 +307,7 @@
           </div>
         </div>
 
-        <div class="usecase-panel reveal" style="--uc:#e08a00;">
+        <div class="usecase-panel reveal" style="--uc:#e08a00; --uc-text:#1a2330;">
           <div class="usecase-copy">
             <span class="uc-tag">edge / iot</span>
             <h3>IoT: ask the far edge a question</h3>

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -10,7 +10,8 @@
   --terminal: #171d26;        /* code stays a dark island */
   --terminal-text: #dbe6f2;
   --terminal-out: #7fd1a8;
-  --line-git: #00857c;        /* the Repo Line */
+  --line-git: #f2a900;        /* the Repo Line — school-bus yellow */
+  --line-git-text: #8a6100;   /* amber-ink: yellow that survives as text */
   --line-blue: #2456c8;
   --line-green: #2e9e44;
   --line-amber: #e08a00;
@@ -45,7 +46,7 @@ body {
 
 main, header, footer { position: relative; z-index: 2; }
 
-a { color: var(--line-git); text-decoration: none; font-weight: 600; }
+a { color: var(--line-git-text); text-decoration: none; font-weight: 600; }
 a:hover { text-decoration: underline; }
 
 code, pre, .mono { font-family: var(--mono); }
@@ -103,7 +104,7 @@ nav.topbar {
   font-weight: 700;
   letter-spacing: 0.1em;
   text-transform: uppercase;
-  color: #fff;
+  color: var(--ink);
   background: var(--line-git);
   border-radius: 999px;
   padding: 6px 16px;
@@ -142,8 +143,8 @@ h1.headline {
 .btn:hover { transform: translateY(-1px); }
 .btn-primary {
   background: var(--line-git);
-  color: #fff;
-  border-color: var(--line-git);
+  color: var(--ink);
+  border-color: var(--ink);
   text-decoration: none;
 }
 .btn-primary:hover { text-decoration: none; filter: brightness(1.06); }
@@ -160,6 +161,14 @@ h1.headline {
   padding: 5px 12px;
   background: var(--card);
 }
+
+/* ---- the bus itself ---- */
+.hero-bus { width: 100%; max-width: 640px; margin: 4px auto 30px; }
+.hero-bus svg { display: block; width: 100%; height: auto; }
+.hb-road { stroke: var(--ink); stroke-width: 4; }
+.hb-dash { stroke: var(--paper-dim); stroke-width: 3; stroke-dasharray: 18 14; animation: hb-roll 1.6s linear infinite; }
+@keyframes hb-roll { to { stroke-dashoffset: -32; } }
+@media (prefers-reduced-motion: reduce) { .hb-dash { animation: none; } }
 
 /* ---- code: always a dark terminal island ---- */
 .codeblock {
@@ -239,7 +248,7 @@ h2.section-title {
   min-width: 150px;
   box-shadow: 0 2px 0 var(--edge);
 }
-.diagram-box.accent { border-color: var(--line-git); color: var(--line-git); font-weight: 600; }
+.diagram-box.accent { border-color: var(--line-git); color: var(--line-git-text); font-weight: 600; }
 .diagram-box .label-sub { color: var(--dim); font-size: 0.74rem; font-weight: 400; display: block; margin-top: 4px; }
 .diagram-arrow { font-family: var(--mono); color: var(--dim); font-size: 1.1rem; margin: 10px 0; }
 .backend-grid {
@@ -267,7 +276,7 @@ h2.section-title {
 .card:hover { border-color: var(--line-git); transform: translateY(-2px); }
 .card .cmd {
   font-family: var(--mono);
-  color: var(--line-git);
+  color: var(--line-git-text);
   font-weight: 700;
   font-size: 0.95rem;
   margin-bottom: 8px;
@@ -287,7 +296,7 @@ th {
   color: var(--dim);
   background: var(--paper-dim);
 }
-td.mono { font-family: var(--mono); color: var(--line-git); font-weight: 600; font-size: 0.84rem; }
+td.mono { font-family: var(--mono); color: var(--line-git-text); font-weight: 600; font-size: 0.84rem; }
 tr:last-child td { border-bottom: none; }
 .yes { color: var(--line-green); font-weight: 700; }
 .no { color: var(--dim); }
@@ -345,7 +354,7 @@ tr:last-child td { border-bottom: none; }
   font-weight: 700;
   letter-spacing: 0.14em;
   text-transform: uppercase;
-  color: #fff;
+  color: var(--uc-text, #fff);
   background: var(--uc);
   border: none;
   border-radius: 999px;
@@ -360,7 +369,7 @@ tr:last-child td { border-bottom: none; }
 .uc-bus {
   width: 100%;
   border-color: var(--uc);
-  color: var(--uc);
+  color: var(--uc-strong, var(--uc));
   font-weight: 700;
   position: relative;
   overflow: hidden;
@@ -422,7 +431,7 @@ tr:last-child td { border-bottom: none; }
 .ga-dot.ga-msg { stroke: var(--line-git); }
 .ga-tag { font: 600 11px var(--mono); text-anchor: middle; }
 .ga-tag.ga-code-t { fill: var(--line-blue); }
-.ga-tag.ga-msg-t { fill: var(--line-git); }
+.ga-tag.ga-msg-t { fill: var(--line-git-text); }
 .ga-pop { opacity: 0; animation: ga-pop 13s linear infinite; }
 @keyframes ga-pop {
   0% { opacity: 0; }


### PR DESCRIPTION
Teal out, school-bus yellow in (yellow fills carry ink text — signage rules; amber-ink for text accents). Hero gains a flat-vector bus: terminal windows with `>_` agents aboard, destination board `→ origin/agentcomm`, rolling dashed road. Metro map: blue main + yellow agentcomm line. Render-checked.