### PR TITLE
fix(site): yellow-bus favicon

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <title>agentcomm — a mailbox for AI agents</title>
 <meta name="description" content="A tiny mailbox/message bus for AI agents. One CLI, pluggable storage backends (local, SQLite/WAL, S3, GCS) behind a single interface. Also a Claude Code plugin." />
-<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Ccircle cx='16' cy='16' r='15' fill='%23060810'/%3E%3Ccircle cx='10' cy='12' r='3' fill='%236ee7ff'/%3E%3Ccircle cx='23' cy='10' r='2.4' fill='%23b794f6'/%3E%3Ccircle cx='22' cy='22' r='2.4' fill='%236ee7ff'/%3E%3Cline x1='10' y1='12' x2='23' y2='10' stroke='%23445' stroke-width='1'/%3E%3Cline x1='10' y1='12' x2='22' y2='22' stroke='%23445' stroke-width='1'/%3E%3C/svg%3E" />
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect x='2' y='7' width='28' height='15' rx='4' fill='%23f2a900' stroke='%231a2330' stroke-width='2'/%3E%3Crect x='6' y='11' width='6' height='5' rx='1.5' fill='%23171d26'/%3E%3Crect x='14' y='11' width='6' height='5' rx='1.5' fill='%23171d26'/%3E%3Crect x='22' y='11' width='5' height='5' rx='1.5' fill='%23dbe6f2'/%3E%3Ccircle cx='9' cy='24' r='4' fill='%231a2330'/%3E%3Ccircle cx='9' cy='24' r='1.6' fill='%23faf7f2'/%3E%3Ccircle cx='23' cy='24' r='4' fill='%231a2330'/%3E%3Ccircle cx='23' cy='24' r='1.6' fill='%23faf7f2'/%3E%3C/svg%3E" />
 <link rel="preconnect" href="https://fonts.googleapis.com" />
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />


### PR DESCRIPTION
The tab icon still wore the retired dark-starfield brand; now it's a tiny yellow bus matching the hero.