### PR TITLE
feat: plugin hooks — bus discipline made mechanical (0.8.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "agentcomm",
       "source": "./",
       "description": "Multi-agent mailbox CLI — any git remote is a bus (git+ssh/github/sqlite/s3/gcs/postgres). register/send/inbox/wait/claim/log/channels so Claude coordinates with other agents or sessions; auto-selects the repo bus inside a git repo.",
-      "version": "0.7.3",
+      "version": "0.8.0",
       "author": {
         "name": "Yoni Davidson"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agentcomm",
   "description": "Multi-agent mailbox CLI — any git remote is a bus (git+ssh/github/sqlite/s3/gcs/postgres). register/send/inbox/wait/claim/log/channels so Claude coordinates with other agents or sessions; auto-selects the repo bus inside a git repo.",
-  "version": "0.7.3",
+  "version": "0.8.0",
   "author": {
     "name": "Yoni Davidson",
     "email": "yonidavidson@tabnine.com"

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,0 +1,27 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/session-start.mjs\"",
+            "timeout": 15
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/stop-inbox-guard.mjs\"",
+            "timeout": 15
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/hooks/lib.mjs
+++ b/hooks/lib.mjs
@@ -1,0 +1,103 @@
+/**
+ * Shared plumbing for the plugin hooks. Hooks must NEVER break a session:
+ * every export fails open (returns null / false) on any error.
+ */
+import { promises as fs } from 'node:fs';
+import * as path from 'node:path';
+import { execFile } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+export const CLI = path.join(here, '..', 'dist', 'cli.js');
+
+export async function readStdinJson() {
+  try {
+    const chunks = [];
+    for await (const c of process.stdin) chunks.push(c);
+    return JSON.parse(Buffer.concat(chunks).toString('utf8'));
+  } catch {
+    return {};
+  }
+}
+
+/** The consent gate: only act where the team put the repo on the bus. */
+export async function onTheBus(cwd) {
+  if (process.env.AGENTCOMM_BACKEND) return true;
+  let dir = cwd || process.cwd();
+  for (;;) {
+    try {
+      const md = await fs.readFile(path.join(dir, 'CLAUDE.md'), 'utf8');
+      if (md.includes('<!-- agentcomm -->')) return true;
+    } catch {
+      /* keep walking */
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) return false;
+    dir = parent;
+  }
+}
+
+/**
+ * Align the derived alias with the agent's own Bash commands. Both inherit
+ * the terminal-session env, so usually nothing is needed; in the gppid
+ * fallback the agent's CLI lands on the harness pid — our ancestor too.
+ */
+async function sessionEnv() {
+  if (
+    process.env.AGENTCOMM_SESSION ||
+    process.env.ITERM_SESSION_ID ||
+    process.env.TERM_SESSION_ID ||
+    process.env.TMUX_PANE
+  ) {
+    return {};
+  }
+  try {
+    const ps = (pid, field) =>
+      new Promise((res, rej) =>
+        execFile('ps', ['-o', `${field}=`, '-p', String(pid)], (e, out) => (e ? rej(e) : res(out.trim()))),
+      );
+    const parent = process.ppid;
+    const comm = await ps(parent, 'comm');
+    // hooks run as `sh -c node …` or as a direct child of the harness;
+    // the harness process is the first non-shell ancestor
+    const harness = /(^|\/)(sh|bash|zsh|dash)$/.test(comm) ? await ps(parent, 'ppid') : String(parent);
+    return { AGENTCOMM_SESSION: `gppid:${harness}` };
+  } catch {
+    return {};
+  }
+}
+
+/** Run the CLI, JSON out + stderr notices. Null on any failure or timeout. */
+export async function cli(args, cwd, timeoutMs = 10_000) {
+  try {
+    const env = { ...process.env, ...(await sessionEnv()) };
+    return await new Promise((resolve) => {
+      const child = execFile(
+        process.execPath,
+        [CLI, ...args],
+        { cwd, env, timeout: timeoutMs, maxBuffer: 4 * 1024 * 1024 },
+        (err, stdout, stderr) => {
+          if (err) return resolve(null);
+          try {
+            resolve({ json: JSON.parse(stdout), stderr });
+          } catch {
+            resolve(null);
+          }
+        },
+      );
+      child.on('error', () => resolve(null));
+    });
+  } catch {
+    return null;
+  }
+}
+
+export function busUriFrom(stderr) {
+  const m = /agentcomm: using (\S+)/.exec(stderr ?? '');
+  return m?.[1] ?? process.env.AGENTCOMM_BACKEND ?? null;
+}
+
+export function aliasFrom(stderr) {
+  const m = /acting as (\S+)/.exec(stderr ?? '');
+  return m?.[1] ?? null;
+}

--- a/hooks/session-start.mjs
+++ b/hooks/session-start.mjs
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+/**
+ * SessionStart hook: in a repo that opted onto the bus (CLAUDE.md marker
+ * from `agentcomm init`, or AGENTCOMM_BACKEND), tell the agent — bus URI,
+ * its derived session alias, and the live roster — before the first prompt.
+ * Silent everywhere else; silent on any failure.
+ */
+import { readStdinJson, onTheBus, cli, busUriFrom, aliasFrom } from './lib.mjs';
+
+const input = await readStdinJson();
+const cwd = input.cwd || process.cwd();
+if (!(await onTheBus(cwd))) process.exit(0);
+
+// peek derives (and announces) the session alias and finds waiting mail;
+// agents supplies the roster. Both read-only.
+const peek = await cli(['peek', '--json'], cwd);
+if (!peek) process.exit(0);
+const res = await cli(['agents', '--json'], cwd);
+
+const bus = busUriFrom(peek.stderr);
+const alias = aliasFrom(peek.stderr);
+const pending = Array.isArray(peek.json) ? peek.json.length : 0;
+const roster = res && Array.isArray(res.json) ? res.json : [];
+const fresh = roster.filter((a) => Date.now() - Date.parse(a.lastSeen) < 10 * 60_000);
+const names = roster.map((a) => a.name + (a.thisSession ? ' (this session)' : '')).join(', ');
+
+const lines = [
+  `agentcomm: this repo is on a message bus${bus ? ` (${bus})` : ''}.`,
+  alias ? `Your derived alias for this session: ${alias} — bare commands use it automatically.` : null,
+  pending ? `${pending} message(s) already waiting for you — run \`agentcomm inbox --json\` first.` : null,
+  roster.length
+    ? `Roster: ${roster.length} agent(s)${fresh.length ? `, ${fresh.length} active in the last 10m` : ''} — ${names}.`
+    : 'Roster: empty — you would be the first to register.',
+  'When coordinating: `agentcomm register`, then `agentcomm inbox --json`; the agentcomm skill has the conventions.',
+].filter(Boolean);
+
+process.stdout.write(
+  JSON.stringify({
+    hookSpecificOutput: { hookEventName: 'SessionStart', additionalContext: lines.join('\n') },
+  }),
+);

--- a/hooks/stop-inbox-guard.mjs
+++ b/hooks/stop-inbox-guard.mjs
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+/**
+ * Stop hook: "always check your inbox before reporting done", enforced.
+ * In an opted-in repo, peek (non-consuming) at this session's derived
+ * mailbox; pending mail blocks the stop once with a pointed reason.
+ * Throttled (45s per cwd), loop-safe (stop_hook_active), fail-open.
+ * Guards the derived session alias only — role aliases taken with --as
+ * are the agent's own responsibility (the skill says so).
+ */
+import { promises as fs } from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { createHash } from 'node:crypto';
+import { readStdinJson, onTheBus, cli, aliasFrom } from './lib.mjs';
+
+const input = await readStdinJson();
+if (input.stop_hook_active) process.exit(0);
+const cwd = input.cwd || process.cwd();
+if (!(await onTheBus(cwd))) process.exit(0);
+
+// throttle: a git-backend peek is a fetch; don't pay it on every quick turn
+const stamp = path.join(os.tmpdir(), `agentcomm-stopguard-${createHash('sha1').update(cwd).digest('hex').slice(0, 12)}`);
+try {
+  const st = await fs.stat(stamp);
+  if (Date.now() - st.mtimeMs < 45_000) process.exit(0);
+} catch {
+  /* first check */
+}
+
+const res = await cli(['peek', '--json'], cwd);
+await fs.writeFile(stamp, '').catch(() => {});
+if (!res || !Array.isArray(res.json) || res.json.length === 0) process.exit(0);
+
+const alias = aliasFrom(res.stderr) ?? 'this session';
+const from = [...new Set(res.json.map((m) => m.from))].join(', ');
+process.stdout.write(
+  JSON.stringify({
+    decision: 'block',
+    reason:
+      `agentcomm: ${res.json.length} unread message(s) for ${alias} on the repo bus (from: ${from}). ` +
+      'Run `agentcomm inbox --json`, act on them (or tell the user why not), then finish.',
+  }),
+);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentcomm",
-  "version": "0.7.3",
+  "version": "0.8.0",
   "description": "A tiny mailbox/message bus for AI agents that shell out to one CLI. Pluggable storage backends behind a single Backend interface.",
   "type": "module",
   "license": "MIT",

--- a/skills/agentcomm/SKILL.md
+++ b/skills/agentcomm/SKILL.md
@@ -121,6 +121,22 @@ backend's own access controls (IAM, grants, file permissions).
 4. Announce yourself (`broadcast --subject status "joining x"`) and work;
    check the `lobby` channel when you need to find who's on what.
 
+## What the plugin's hooks already do for you (Claude Code)
+
+In repos that ran `agentcomm init` (the `<!-- agentcomm -->` marker in
+CLAUDE.md is the consent gate), this plugin ships hooks that make part of
+the discipline mechanical — don't duplicate them:
+
+- **Session start**: you receive a context note with the bus URI, your
+  derived session alias, mail already waiting, and the live roster. No need
+  to probe for a bus — if the note isn't there, the repo isn't on one.
+- **Stopping**: a guard peeks (non-consuming) at your derived mailbox and
+  blocks finishing once if unread messages exist — handle them via
+  `agentcomm inbox --json` (or tell the user why not), then finish.
+
+Still yours: registering, everything about ROLE aliases (`--as` mailboxes
+are not guarded — check them yourself), acks/threads, and all sends.
+
 ## Delegating the bus to a subagent (keep the main flow clean)
 
 If your harness supports subagents (e.g. Claude Code's Agent tool), prefer

--- a/test/hooks.e2e.test.ts
+++ b/test/hooks.e2e.test.ts
@@ -1,0 +1,185 @@
+/**
+ * e2e for the plugin hooks (issue #54): session-start bus notice and the
+ * stop-time inbox guard. Hooks are spawned exactly as Claude Code does —
+ * stdin JSON in, stdout JSON out — against a marked temp repo on file://.
+ */
+import { describe, it, expect, afterEach, beforeAll } from 'vitest';
+import { promises as fs } from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawn, execFileSync } from 'node:child_process';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const root = path.join(here, '..');
+
+const tmpRoots: string[] = [];
+async function mkTmp(): Promise<string> {
+  const dir = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), 'agentcomm-hooks-')));
+  tmpRoots.push(dir);
+  return dir;
+}
+afterEach(async () => {
+  for (const dir of tmpRoots.splice(0)) await fs.rm(dir, { recursive: true, force: true });
+});
+
+beforeAll(() => {
+  execFileSync('npm', ['run', 'build'], { cwd: root, stdio: 'ignore' });
+});
+
+async function markedRepo(): Promise<string> {
+  const dir = await mkTmp();
+  execFileSync('git', ['-C', dir, 'init', '-q']);
+  execFileSync('git', ['-C', dir, 'config', 'user.email', 'hooky@corp.example']);
+  await fs.writeFile(path.join(dir, 'CLAUDE.md'), '<!-- agentcomm -->\n## Agent coordination (agentcomm)\n');
+  return dir;
+}
+
+function runHook(
+  script: string,
+  stdinJson: object,
+  cwd: string,
+): Promise<{ code: number; stdout: string }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [path.join(root, 'hooks', script)], {
+      stdio: ['pipe', 'pipe', 'pipe'],
+      cwd,
+      env: {
+        PATH: process.env.PATH,
+        HOME: process.env.HOME,
+        AGENTCOMM_BACKEND: `file://${path.join(cwd, '.bus')}`,
+        AGENTCOMM_NO_GIT_PROBE: '1',
+        AGENTCOMM_SESSION: 'hook-session',
+        TMPDIR: cwd, // isolate the stop-guard throttle stamp per test
+      },
+    });
+    let stdout = '';
+    child.stdout.on('data', (d) => (stdout += d.toString()));
+    child.on('error', reject);
+    child.on('exit', (code) => resolve({ code: code ?? -1, stdout }));
+    child.stdin.end(JSON.stringify(stdinJson));
+  });
+}
+
+function cliSync(args: string[], cwd: string, as?: string): void {
+  execFileSync(
+    process.execPath,
+    [path.join(root, 'dist', 'cli.js'), ...args, ...(as ? ['--as', as] : [])],
+    {
+      cwd,
+      stdio: 'ignore',
+      env: {
+        PATH: process.env.PATH,
+        HOME: process.env.HOME,
+        AGENTCOMM_BACKEND: `file://${path.join(cwd, '.bus')}`,
+        AGENTCOMM_NO_GIT_PROBE: '1',
+        AGENTCOMM_SESSION: 'hook-session',
+      },
+    },
+  );
+}
+
+describe('plugin hooks: bus discipline made mechanical', () => {
+  it('session-start announces bus, derived alias, and roster in a marked repo', async () => {
+    const dir = await markedRepo();
+    cliSync(['register'], dir, 'reviewer');
+
+    const r = await runHook('session-start.mjs', { cwd: dir, hook_event_name: 'SessionStart' }, dir);
+    expect(r.code).toBe(0);
+    const out = JSON.parse(r.stdout) as {
+      hookSpecificOutput: { hookEventName: string; additionalContext: string };
+    };
+    expect(out.hookSpecificOutput.hookEventName).toBe('SessionStart');
+    const ctx = out.hookSpecificOutput.additionalContext;
+    expect(ctx).toContain('on a message bus');
+    expect(ctx).toMatch(/derived alias for this session: hooky-[0-9a-f]{4}/);
+    expect(ctx).toContain('reviewer');
+  });
+
+  it('session-start stays silent outside opted-in repos', async () => {
+    const dir = await mkTmp(); // no marker
+    const r = await new Promise<{ code: number; stdout: string }>((resolve, reject) => {
+      const child = spawn(process.execPath, [path.join(root, 'hooks', 'session-start.mjs')], {
+        stdio: ['pipe', 'pipe', 'pipe'],
+        cwd: dir,
+        env: { PATH: process.env.PATH, HOME: process.env.HOME }, // no AGENTCOMM_BACKEND either
+      });
+      let stdout = '';
+      child.stdout.on('data', (d) => (stdout += d.toString()));
+      child.on('error', reject);
+      child.on('exit', (code) => resolve({ code: code ?? -1, stdout }));
+      child.stdin.end(JSON.stringify({ cwd: dir }));
+    });
+    expect(r.code).toBe(0);
+    expect(r.stdout).toBe('');
+  });
+
+  it('stop guard blocks when the derived mailbox has pending mail, and passes it clean', async () => {
+    const dir = await markedRepo();
+    cliSync(['register'], dir); // derived alias, session-aligned via AGENTCOMM_SESSION
+    cliSync(['register'], dir, 'sender');
+
+    // clean mailbox → no block
+    const clean = await runHook('stop-inbox-guard.mjs', { cwd: dir }, dir);
+    expect(clean.code).toBe(0);
+    expect(clean.stdout).toBe('');
+
+    // note: within the 45s throttle a pending message would be missed — each
+    // test uses its own TMPDIR, but inside one test we must clear the stamp
+    for (const f of await fs.readdir(dir)) {
+      if (f.startsWith('agentcomm-stopguard-')) await fs.rm(path.join(dir, f));
+    }
+
+    const hooky = 'hooky-'; // derived name prefix; find the real one from the roster
+    const roster = JSON.parse(
+      execFileSync(process.execPath, [path.join(root, 'dist', 'cli.js'), 'agents', '--json'], {
+        cwd: dir,
+        env: {
+          PATH: process.env.PATH,
+          HOME: process.env.HOME,
+          AGENTCOMM_BACKEND: `file://${path.join(dir, '.bus')}`,
+          AGENTCOMM_NO_GIT_PROBE: '1',
+          AGENTCOMM_SESSION: 'hook-session',
+        },
+      }).toString(),
+    ) as { name: string }[];
+    const me = roster.map((a) => a.name).find((n) => n.startsWith(hooky))!;
+    cliSync(['send', me, 'wrap it up'], dir, 'sender');
+
+    const blocked = await runHook('stop-inbox-guard.mjs', { cwd: dir }, dir);
+    expect(blocked.code).toBe(0);
+    const out = JSON.parse(blocked.stdout) as { decision: string; reason: string };
+    expect(out.decision).toBe('block');
+    expect(out.reason).toContain('unread message');
+    expect(out.reason).toContain('from: sender');
+  });
+
+  it('stop guard honors stop_hook_active (no loops) and throttles repeat checks', async () => {
+    const dir = await markedRepo();
+    cliSync(['register'], dir);
+    cliSync(['register'], dir, 'sender');
+
+    const looped = await runHook('stop-inbox-guard.mjs', { cwd: dir, stop_hook_active: true }, dir);
+    expect(looped.stdout).toBe('');
+
+    // first real check writes the stamp…
+    await runHook('stop-inbox-guard.mjs', { cwd: dir }, dir);
+    // …so even with mail now pending, the throttled re-check stays silent
+    const roster = JSON.parse(
+      execFileSync(process.execPath, [path.join(root, 'dist', 'cli.js'), 'agents', '--json'], {
+        cwd: dir,
+        env: {
+          PATH: process.env.PATH,
+          HOME: process.env.HOME,
+          AGENTCOMM_BACKEND: `file://${path.join(dir, '.bus')}`,
+          AGENTCOMM_NO_GIT_PROBE: '1',
+          AGENTCOMM_SESSION: 'hook-session',
+        },
+      }).toString(),
+    ) as { name: string }[];
+    const me = roster.map((a) => a.name).find((n) => n.startsWith('hooky-'))!;
+    cliSync(['send', me, 'you have mail'], dir, 'sender');
+    const throttled = await runHook('stop-inbox-guard.mjs', { cwd: dir }, dir);
+    expect(throttled.stdout).toBe('');
+  });
+});


### PR DESCRIPTION
Closes #54. SessionStart injects bus+alias+roster+waiting-mail context in opted-in repos; Stop blocks once on unread derived-mailbox messages (throttled, loop-safe, fail-open everywhere). Skill documents what the hooks own vs what stays with the agent. 4 new hook e2e tests spawning the scripts harness-style.