### PR TITLE
fix(hooks): session-start registers — on the network by default, for real (0.8.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "agentcomm",
       "source": "./",
       "description": "Multi-agent mailbox CLI — any git remote is a bus (git+ssh/github/sqlite/s3/gcs/postgres). register/send/inbox/wait/claim/log/channels so Claude coordinates with other agents or sessions; auto-selects the repo bus inside a git repo.",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "author": {
         "name": "Yoni Davidson"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agentcomm",
   "description": "Multi-agent mailbox CLI — any git remote is a bus (git+ssh/github/sqlite/s3/gcs/postgres). register/send/inbox/wait/claim/log/channels so Claude coordinates with other agents or sessions; auto-selects the repo bus inside a git repo.",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "author": {
     "name": "Yoni Davidson",
     "email": "yonidavidson@tabnine.com"

--- a/hooks/session-start.mjs
+++ b/hooks/session-start.mjs
@@ -11,27 +11,41 @@ const input = await readStdinJson();
 const cwd = input.cwd || process.cwd();
 if (!(await onTheBus(cwd))) process.exit(0);
 
-// peek derives (and announces) the session alias and finds waiting mail;
-// agents supplies the roster. Both read-only.
+// The CLAUDE.md contract says agents register at session start — the hook
+// does it (heartbeat onto the roster), throttled so restarts don't spam
+// bus commits, then reports waiting mail and the roster.
+import('node:fs');
+const { promises: fsp } = await import('node:fs');
+const { tmpdir } = await import('node:os');
+const { createHash } = await import('node:crypto');
+const { join } = await import('node:path');
+const stamp = join(tmpdir(), `agentcomm-register-${createHash('sha1').update(cwd).digest('hex').slice(0, 12)}`);
+let fresh = false;
+try {
+  fresh = Date.now() - (await fsp.stat(stamp)).mtimeMs < 10 * 60_000;
+} catch { /* never registered from here */ }
+
+const reg = fresh ? null : await cli(['register', '--json'], cwd, 20_000);
+if (reg) await fsp.writeFile(stamp, '').catch(() => {});
 const peek = await cli(['peek', '--json'], cwd);
 if (!peek) process.exit(0);
 const res = await cli(['agents', '--json'], cwd);
 
-const bus = busUriFrom(peek.stderr);
-const alias = aliasFrom(peek.stderr);
+const bus = busUriFrom(peek.stderr) ?? busUriFrom(reg?.stderr);
+const alias = aliasFrom(peek.stderr) ?? reg?.json?.name;
 const pending = Array.isArray(peek.json) ? peek.json.length : 0;
 const roster = res && Array.isArray(res.json) ? res.json : [];
-const fresh = roster.filter((a) => Date.now() - Date.parse(a.lastSeen) < 10 * 60_000);
+const active = roster.filter((a) => Date.now() - Date.parse(a.lastSeen) < 10 * 60_000);
 const names = roster.map((a) => a.name + (a.thisSession ? ' (this session)' : '')).join(', ');
 
 const lines = [
   `agentcomm: this repo is on a message bus${bus ? ` (${bus})` : ''}.`,
-  alias ? `Your derived alias for this session: ${alias} — bare commands use it automatically.` : null,
+  alias ? `You are registered as ${alias} — bare commands use this alias automatically.` : null,
   pending ? `${pending} message(s) already waiting for you — run \`agentcomm inbox --json\` first.` : null,
   roster.length
-    ? `Roster: ${roster.length} agent(s)${fresh.length ? `, ${fresh.length} active in the last 10m` : ''} — ${names}.`
+    ? `Roster: ${roster.length} agent(s)${active.length ? `, ${active.length} active in the last 10m` : ''} — ${names}.`
     : 'Roster: empty — you would be the first to register.',
-  'When coordinating: `agentcomm register`, then `agentcomm inbox --json`; the agentcomm skill has the conventions.',
+  'To coordinate: `agentcomm send <to> <msg>` / `inbox --json` / `wait`; the agentcomm skill has the conventions.',
 ].filter(Boolean);
 
 process.stdout.write(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentcomm",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "A tiny mailbox/message bus for AI agents that shell out to one CLI. Pluggable storage backends behind a single Backend interface.",
   "type": "module",
   "license": "MIT",

--- a/skills/agentcomm/SKILL.md
+++ b/skills/agentcomm/SKILL.md
@@ -127,14 +127,15 @@ In repos that ran `agentcomm init` (the `<!-- agentcomm -->` marker in
 CLAUDE.md is the consent gate), this plugin ships hooks that make part of
 the discipline mechanical — don't duplicate them:
 
-- **Session start**: you receive a context note with the bus URI, your
-  derived session alias, mail already waiting, and the live roster. No need
-  to probe for a bus — if the note isn't there, the repo isn't on one.
+- **Session start**: the hook REGISTERS you (throttled heartbeat) and hands
+  you a context note — bus URI, your alias, mail already waiting, the live
+  roster. No need to probe or register again — if the note isn't there,
+  the repo isn't on a bus.
 - **Stopping**: a guard peeks (non-consuming) at your derived mailbox and
   blocks finishing once if unread messages exist — handle them via
   `agentcomm inbox --json` (or tell the user why not), then finish.
 
-Still yours: registering, everything about ROLE aliases (`--as` mailboxes
+Still yours: everything about ROLE aliases (`--as` mailboxes
 are not guarded — check them yourself), acks/threads, and all sends.
 
 ## Delegating the bus to a subagent (keep the main flow clean)

--- a/test/hooks.e2e.test.ts
+++ b/test/hooks.e2e.test.ts
@@ -80,7 +80,7 @@ function cliSync(args: string[], cwd: string, as?: string): void {
 }
 
 describe('plugin hooks: bus discipline made mechanical', () => {
-  it('session-start announces bus, derived alias, and roster in a marked repo', async () => {
+  it('session-start REGISTERS the session onto the roster and announces it', async () => {
     const dir = await markedRepo();
     cliSync(['register'], dir, 'reviewer');
 
@@ -92,8 +92,25 @@ describe('plugin hooks: bus discipline made mechanical', () => {
     expect(out.hookSpecificOutput.hookEventName).toBe('SessionStart');
     const ctx = out.hookSpecificOutput.additionalContext;
     expect(ctx).toContain('on a message bus');
-    expect(ctx).toMatch(/derived alias for this session: hooky-[0-9a-f]{4}/);
+    expect(ctx).toMatch(/registered as hooky-[0-9a-f]{4}/);
     expect(ctx).toContain('reviewer');
+
+    // the register was real: the derived alias is on the roster now
+    const roster = execFileSync(
+      process.execPath,
+      [path.join(root, 'dist', 'cli.js'), 'agents', '--json'],
+      {
+        cwd: dir,
+        env: {
+          PATH: process.env.PATH,
+          HOME: process.env.HOME,
+          AGENTCOMM_BACKEND: `file://${path.join(dir, '.bus')}`,
+          AGENTCOMM_NO_GIT_PROBE: '1',
+          AGENTCOMM_SESSION: 'hook-session',
+        },
+      },
+    ).toString();
+    expect(roster).toMatch(/hooky-[0-9a-f]{4}/);
   });
 
   it('session-start stays silent outside opted-in repos', async () => {


### PR DESCRIPTION
A fresh session got the note but never registered (its task didn't involve coordination) — invisible on the roster. The hook now performs the CLAUDE.md contract itself: register (10-min throttle per cwd), then announce alias + mail + roster. Test asserts the roster gains the derived alias.