### PR TITLE
fix(hooks): stop-guard reason reads as delivery, not error (0.9.2)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "agentcomm",
       "source": "./",
       "description": "Multi-agent mailbox CLI — any git remote is a bus (git+ssh/github/sqlite/s3/gcs/postgres). register/send/inbox/wait/claim/log/channels so Claude coordinates with other agents or sessions; auto-selects the repo bus inside a git repo.",
-      "version": "0.9.1",
+      "version": "0.9.2",
       "author": {
         "name": "Yoni Davidson"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agentcomm",
   "description": "Multi-agent mailbox CLI — any git remote is a bus (git+ssh/github/sqlite/s3/gcs/postgres). register/send/inbox/wait/claim/log/channels so Claude coordinates with other agents or sessions; auto-selects the repo bus inside a git repo.",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "author": {
     "name": "Yoni Davidson",
     "email": "yonidavidson@tabnine.com"

--- a/hooks/stop-inbox-guard.mjs
+++ b/hooks/stop-inbox-guard.mjs
@@ -37,7 +37,8 @@ process.stdout.write(
   JSON.stringify({
     decision: 'block',
     reason:
-      `agentcomm: ${res.json.length} unread message(s) for ${alias} on the repo bus (from: ${from}). ` +
-      'Run `agentcomm inbox --json`, act on them (or tell the user why not), then finish.',
+      `agentcomm delivery (working as intended — not an error): ${res.json.length} unread bus message(s) ` +
+      `for ${alias} (from: ${from}). Read them with \`agentcomm inbox --json\`, act or tell the user why not, ` +
+      'then finish.',
   }),
 );

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentcomm",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "A tiny mailbox/message bus for AI agents that shell out to one CLI. Pluggable storage backends behind a single Backend interface.",
   "type": "module",
   "license": "MIT",

--- a/test/hooks.e2e.test.ts
+++ b/test/hooks.e2e.test.ts
@@ -167,7 +167,7 @@ describe('plugin hooks: bus discipline made mechanical', () => {
     expect(blocked.code).toBe(0);
     const out = JSON.parse(blocked.stdout) as { decision: string; reason: string };
     expect(out.decision).toBe('block');
-    expect(out.reason).toContain('unread message');
+    expect(out.reason).toContain('unread bus message');
     expect(out.reason).toContain('from: sender');
   });
 


### PR DESCRIPTION
Users see the harness's 'Stop hook error' prefix on every blocking stop; the reason text now defuses it explicitly.