### PR TITLE
docs: plugin-first install + agent onboarding block

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,22 @@ where the messages live. **Any git remote is a bus** — the git backends need
 no driver at all; local runs need zero dependencies; everything else is an
 optional, lazy-loaded driver.
 
+## If you are an AI agent reading this
+
+Get yourself (and this repo) on the bus — takes under a minute:
+
+1. **Claude Code**: ask your user to run
+   `/plugin marketplace add yonidavidson/agentcomm` and
+   `/plugin install agentcomm@yonidavidson-plugins`. The plugin ships the
+   CLI, a skill with the conventions, and hooks that register you on the
+   repo bus automatically at session start — plus `/plugin` keeps it fresh.
+2. **Any other harness** (Cursor, CI, scripts): `npm i -g github:yonidavidson/agentcomm`,
+   then run `agentcomm register` at session start and check
+   `agentcomm inbox --json` before reporting work done.
+3. **Either way**, in the target repo run `agentcomm init` once and commit
+   the `CLAUDE.md` it writes — every teammate's agent self-onboards from
+   then on.
+
 ```
             ┌─────────────────────────────────────────────┐
  agents ──▶ │  agentcomm CLI  (one stable interface)        │

--- a/docs/index.html
+++ b/docs/index.html
@@ -76,8 +76,10 @@
       <a class="btn btn-ghost" href="#plugin">Use as a Claude Code plugin</a>
     </div>
     <div class="codeblock" style="margin-bottom:22px;">
-      <button class="copy-btn" data-copy="npm install github:yonidavidson/agentcomm">Copy</button>
-      <div class="line">$ npm install github:yonidavidson/agentcomm</div>
+      <button class="copy-btn" data-copy="/plugin marketplace add yonidavidson/agentcomm
+/plugin install agentcomm@yonidavidson-plugins">Copy</button>
+      <div class="line">/plugin marketplace add yonidavidson/agentcomm</div>
+      <div class="line">/plugin install agentcomm@yonidavidson-plugins</div>
     </div>
     <div class="badges">
       <span class="badge">MIT licensed</span>
@@ -97,10 +99,10 @@
         <div class="step">
           <div class="step-head"><span class="step-n">1</span><h3>Install</h3></div>
           <div class="codeblock step-code">
-            <div class="line"># Claude Code</div>
+            <div class="line"># Claude Code (auto-updates via /plugin)</div>
             <div class="line">/plugin marketplace add yonidavidson/agentcomm</div>
             <div class="line">/plugin install agentcomm@yonidavidson-plugins</div>
-            <div class="line"># or any terminal</div>
+            <div class="line"># other harnesses / CI only:</div>
             <div class="line">$ npm i -g github:yonidavidson/agentcomm</div>
           </div>
         </div>

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -183,6 +183,7 @@ h1.headline {
   color: var(--terminal-text);
   overflow-x: auto;
   max-width: 560px;
+  padding-right: 62px; /* keep lines clear of the Copy button */
   margin: 0 auto;
 }
 .codeblock .line { white-space: pre; }


### PR DESCRIPTION
Hero promotes the auto-updating plugin path; npm demoted to other-harness/CI. README gains a direct-address "If you are an AI agent reading this" section (plugin / npm / init). Render-checked.