### PR TITLE
refactor(hooks): heartbeat rides the digest; stop guard read-only (0.12.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "agentcomm",
       "source": "./",
       "description": "Multi-agent mailbox CLI — any git remote is a bus (git+ssh/github/sqlite/s3/gcs/postgres). register/send/inbox/wait/claim/log/channels so Claude coordinates with other agents or sessions; auto-selects the repo bus inside a git repo.",
-      "version": "0.12.0",
+      "version": "0.12.1",
       "author": {
         "name": "Yoni Davidson"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agentcomm",
   "description": "Multi-agent mailbox CLI — any git remote is a bus (git+ssh/github/sqlite/s3/gcs/postgres). register/send/inbox/wait/claim/log/channels so Claude coordinates with other agents or sessions; auto-selects the repo bus inside a git repo.",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "author": {
     "name": "Yoni Davidson",
     "email": "yonidavidson@tabnine.com"

--- a/hooks/prompt-digest.mjs
+++ b/hooks/prompt-digest.mjs
@@ -23,6 +23,11 @@ try {
   if (Date.now() - (await fs.stat(stamp)).mtimeMs < 5 * 60_000) process.exit(0);
 } catch { /* first digest */ }
 
+// Heartbeat rides the digest: a prompt is the strongest "this session is
+// alive" signal, and both want the same ~5min cadence. register is async
+// through the daemon outbox, so this costs ~0.3s. No --status: a heartbeat
+// never overwrites a declared status.
+await cli(['register', '--json'], cwd, 3_000);
 const peek = await cli(['peek', '--json'], cwd, 3_000);
 const agents = await cli(['agents', '--json'], cwd, 3_000);
 await fs.writeFile(stamp, '').catch(() => {});

--- a/hooks/stop-inbox-guard.mjs
+++ b/hooks/stop-inbox-guard.mjs
@@ -18,25 +18,9 @@ if (input.stop_hook_active) process.exit(0);
 const cwd = input.cwd || process.cwd();
 if (!(await onTheBus(cwd))) process.exit(0);
 
-// Heartbeat: re-register at turn end (throttled) so the roster's lastSeen
-// means "alive within minutes", not "boarded once at session start".
-{
-  const { promises: fsp } = await import('node:fs');
-  const { tmpdir } = await import('node:os');
-  const { createHash } = await import('node:crypto');
-  const { join } = await import('node:path');
-  const beat = join(
-    tmpdir(),
-    `agentcomm-heartbeat-${createHash('sha1').update(cwd).digest('hex').slice(0, 12)}`,
-  );
-  let due = true;
-  try {
-    due = Date.now() - (await fsp.stat(beat)).mtimeMs > 300_000;
-  } catch { /* first beat */ }
-  if (due && (await cli(['register', '--json'], cwd))) {
-    await fsp.writeFile(beat, '').catch(() => {});
-  }
-}
+// (The presence heartbeat rides the prompt digest — this hook is purely
+// the delivery guarantee.)
+
 
 // throttle: a git-backend peek is a fetch; don't pay it on every quick turn
 const stamp = path.join(os.tmpdir(), `agentcomm-stopguard-${createHash('sha1').update(cwd).digest('hex').slice(0, 12)}`);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentcomm",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "A tiny mailbox/message bus for AI agents that shell out to one CLI. Pluggable storage backends behind a single Backend interface.",
   "type": "module",
   "license": "MIT",

--- a/skills/agentcomm/SKILL.md
+++ b/skills/agentcomm/SKILL.md
@@ -147,11 +147,11 @@ the discipline mechanical — don't duplicate them:
   you a context note — bus URI, your alias, mail already waiting, the live
   roster. No need to probe or register again — if the note isn't there,
   the repo isn't on a bus.
-- **Stopping**: a guard peeks (non-consuming) at your derived mailbox and
-  blocks finishing once if unread messages exist — handle them via
+- **Stopping**: a read-only guard peeks (non-consuming) at your derived
+  mailbox and blocks finishing once if unread messages exist — handle them via
   `agentcomm inbox --json` (or tell the user why not), then finish.
-- **During the session**: a throttled digest (≤ once per 5min, only when
-  there is news) may appear in your context — unread count, riders that
+- **During the session**: a throttled digest (≤ once per 5min) heartbeats
+  your presence and — only when there is news — may appear in your context — unread count, riders that
   joined, and what active agents say they're doing. Act on it like any bus
   fact; no need to re-check what it reports.
 

--- a/test/hooks.e2e.test.ts
+++ b/test/hooks.e2e.test.ts
@@ -193,9 +193,9 @@ describe('plugin hooks: bus discipline made mechanical', () => {
     expect(out.reason).toContain('from: sender');
   });
 
-  it('stop guard heartbeats: a backdated registration gets a fresh lastSeen at turn end', async () => {
+  it('the digest heartbeats: a backdated registration gets a fresh lastSeen at prompt time', async () => {
     const dir = await markedRepo();
-    cliSync(['register'], dir); // derived alias record exists
+    cliSync(['register'], dir);
 
     const agentsDir = path.join(dir, '.bus', 'agents');
     const recFile = (await fs.readdir(agentsDir)).find((f) => f.startsWith('hooky-'))!;
@@ -205,19 +205,19 @@ describe('plugin hooks: bus discipline made mechanical', () => {
     const old = new Date(Date.now() - 3600_000).toISOString();
     await fs.writeFile(path.join(agentsDir, recFile), JSON.stringify({ ...rec, lastSeen: old }));
 
-    await runHook('stop-inbox-guard.mjs', { cwd: dir }, dir);
+    await runHook('prompt-digest.mjs', { cwd: dir }, dir);
     const after = JSON.parse(await fs.readFile(path.join(agentsDir, recFile), 'utf8')) as {
       lastSeen: string;
     };
     expect(Date.parse(after.lastSeen)).toBeGreaterThan(Date.parse(old)); // heartbeat bumped it
 
-    // throttle: backdate again — an immediate second stop must NOT re-beat
+    // the stop guard, by contrast, is read-only now: backdate again, run it, unchanged
     await fs.writeFile(path.join(agentsDir, recFile), JSON.stringify({ ...rec, lastSeen: old }));
     await runHook('stop-inbox-guard.mjs', { cwd: dir }, dir);
-    const throttled = JSON.parse(await fs.readFile(path.join(agentsDir, recFile), 'utf8')) as {
+    const untouched = JSON.parse(await fs.readFile(path.join(agentsDir, recFile), 'utf8')) as {
       lastSeen: string;
     };
-    expect(throttled.lastSeen).toBe(old);
+    expect(untouched.lastSeen).toBe(old);
   });
 
   it('prompt digest: news-only, throttled, silent when quiet', async () => {


### PR DESCRIPTION
Dedup from review: one 5-min turn-boundary moment owns the presence write (prompt digest: register→peek→agents under one throttle stamp); the stop hook is now purely the unread-mail guarantee. e2e asserts digest-bumps / stop-guard-doesn't.