### PR TITLE
fix(test): daemon teardown race (0.13.1) — and merge-gate lesson applied

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "agentcomm",
       "source": "./",
       "description": "Multi-agent mailbox CLI — any git remote is a bus (git+ssh/github/sqlite/s3/gcs/postgres). register/send/inbox/wait/claim/log/channels so Claude coordinates with other agents or sessions; auto-selects the repo bus inside a git repo.",
-      "version": "0.13.0",
+      "version": "0.13.1",
       "author": {
         "name": "Yoni Davidson"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agentcomm",
   "description": "Multi-agent mailbox CLI — any git remote is a bus (git+ssh/github/sqlite/s3/gcs/postgres). register/send/inbox/wait/claim/log/channels so Claude coordinates with other agents or sessions; auto-selects the repo bus inside a git repo.",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "author": {
     "name": "Yoni Davidson",
     "email": "yonidavidson@tabnine.com"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentcomm",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "A tiny mailbox/message bus for AI agents that shell out to one CLI. Pluggable storage backends behind a single Backend interface.",
   "type": "module",
   "license": "MIT",

--- a/test/daemon.e2e.test.ts
+++ b/test/daemon.e2e.test.ts
@@ -61,7 +61,20 @@ function run(
 afterEach(async () => {
   for (const dir of tmpRoots.splice(0)) {
     await run(['daemon', 'stop'], dir).catch(() => {});
-    await fs.rm(dir, { recursive: true, force: true });
+    // stop acks before the daemon fully exits (it drains its outbox first) —
+    // wait for the pid file to disappear so rm doesn't race daemon writes
+    const dsock = path.join(dir, 'dsock');
+    for (let i = 0; i < 30; i++) {
+      let alive = false;
+      try {
+        alive = (await fs.readdir(dsock)).some((f) => f.endsWith('.pid'));
+      } catch {
+        break; // no daemon dir at all
+      }
+      if (!alive) break;
+      await new Promise((r) => setTimeout(r, 100));
+    }
+    await fs.rm(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 200 });
   }
 });
 
@@ -70,11 +83,11 @@ describe('bus daemon: same semantics, immediate answers', () => {
     const dir = await mkTmp();
 
     const reg = await run(['register', '--as', 'alpha', '--daemon'], dir);
-    expect(reg.code).toBe(0);
+    expect(reg.code, reg.stderr).toBe(0);
     expect(reg.stdout).toContain('registered alpha');
 
     const status = await run(['daemon', 'status', '--json'], dir);
-    expect(status.code).toBe(0);
+    expect(status.code, status.stderr).toBe(0);
     const info = JSON.parse(status.stdout) as { running: boolean; pollMs: number; claimable: boolean };
     expect(info.running).toBe(true);
     expect(info.pollMs).toBe(500); // AGENTCOMM_POLL_MS=300 clamped to the 500ms floor


### PR DESCRIPTION
PR #70 merged on red (chain gated on finished, not passed — tooling fixed: merges now require pass). Root cause of the red: teardown rm racing the daemon's post-ack outbox drain. Now waits for pid-file exit + rm with retries; asserts carry stderr. 3× locally green.