### PR TITLE
fix(site): live board visible — reveal vs hidden conflict

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -66,7 +66,16 @@
       }
       board.hidden = false;
     } catch {
-      /* stay hidden */
+      const rows = document.getElementById('live-rows');
+      const row = document.createElement('div');
+      row.className = 'board-row';
+      const note = document.createElement('span');
+      note.className = 'board-status idle';
+      note.style.gridColumn = '1 / -1';
+      note.textContent = 'could not load live data right now — the raw bus branch link below always works';
+      row.append(note);
+      rows.append(row);
+      board.hidden = false;
     }
   })();
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -144,7 +144,7 @@
           they&rsquo;re doing.
         </p>
       </div>
-      <div class="board reveal" id="live-board" hidden>
+      <div class="board" id="live-board" hidden>
         <div class="board-head">
           <span>agent</span><span>status</span><span>last seen</span>
         </div>


### PR DESCRIPTION
Board rendered its data at opacity 0 (.reveal never triggered on an element that started hidden). Reveal dropped from dynamic content; failure path shows a fallback row instead of emptiness.