### PR TITLE
fix: ship bin/agentcomm — bare command works, no global install (0.16.2)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "agentcomm",
       "source": "./",
       "description": "Multi-agent mailbox CLI — any git remote is a bus (git+ssh/github/sqlite/s3/gcs/postgres). register/send/inbox/wait/claim/log/channels so Claude coordinates with other agents or sessions; auto-selects the repo bus inside a git repo.",
-      "version": "0.16.1",
+      "version": "0.16.2",
       "author": {
         "name": "Yoni Davidson"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agentcomm",
   "description": "Multi-agent mailbox CLI — any git remote is a bus (git+ssh/github/sqlite/s3/gcs/postgres). register/send/inbox/wait/claim/log/channels so Claude coordinates with other agents or sessions; auto-selects the repo bus inside a git repo.",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "author": {
     "name": "Yoni Davidson",
     "email": "yonidavidson@tabnine.com"

--- a/bin/agentcomm
+++ b/bin/agentcomm
@@ -1,0 +1,14 @@
+#!/bin/sh
+# agentcomm launcher: Claude Code adds this plugin's bin/ to PATH, so agents
+# can run bare `agentcomm ...` exactly as CLAUDE.md/SKILL.md document. Resolves
+# the prebuilt CLI relative to this script (survives version-dir upgrades).
+self="$0"
+while [ -h "$self" ]; do
+  link="$(readlink "$self")"
+  case "$link" in
+    /*) self="$link" ;;
+    *) self="$(dirname "$self")/$link" ;;
+  esac
+done
+dir="$(cd "$(dirname "$self")" && pwd)"
+exec node "$dir/../dist/cli.js" "$@"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentcomm",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "description": "A tiny mailbox/message bus for AI agents that shell out to one CLI. Pluggable storage backends behind a single Backend interface.",
   "type": "module",
   "license": "MIT",
@@ -24,6 +24,7 @@
   "types": "dist/index.d.ts",
   "files": [
     "dist",
+    "bin",
     "README.md",
     "LICENSE"
   ],

--- a/skills/agentcomm/SKILL.md
+++ b/skills/agentcomm/SKILL.md
@@ -11,14 +11,21 @@ and exits.
 
 ## Running the CLI
 
-This plugin ships a prebuilt copy. Invoke it with Node directly:
+This plugin puts an `agentcomm` launcher on PATH (its `bin/` dir), so in a
+Claude Code session just run it bare — exactly as this repo's CLAUDE.md
+shows:
+
+```bash
+agentcomm <command> [args] [flags]
+```
+
+If `agentcomm` is somehow not found (a harness that doesn't add plugin
+bin/ to PATH), fall back to the prebuilt copy directly — identical
+behaviour:
 
 ```bash
 node "$CLAUDE_PLUGIN_ROOT/dist/cli.js" <command> [args] [flags]
 ```
-
-(If the user already has `agentcomm` installed globally or on `PATH`, that
-works identically — same commands, same flags.)
 
 ## Picking a backend (do this first)
 

--- a/test/bin-shim.e2e.test.ts
+++ b/test/bin-shim.e2e.test.ts
@@ -1,0 +1,49 @@
+/**
+ * The plugin ships bin/agentcomm so Claude Code (which adds each plugin's
+ * bin/ to PATH) lets agents run bare `agentcomm ...` — exactly what the
+ * init-written CLAUDE.md tells them to do. This proves the wrapper resolves
+ * the prebuilt CLI and runs from an unrelated cwd.
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import { promises as fs } from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawn, execFileSync } from 'node:child_process';
+
+const root = path.join(path.dirname(fileURLToPath(import.meta.url)), '..');
+const shim = path.join(root, 'bin', 'agentcomm');
+
+beforeAll(() => {
+  execFileSync('npm', ['run', 'build'], { cwd: root, stdio: 'ignore' });
+});
+
+describe('bin/agentcomm launcher', () => {
+  it('is executable and runs the CLI from an unrelated working directory', async () => {
+    const st = await fs.stat(shim);
+    expect(st.mode & 0o111).toBeTruthy(); // has an exec bit
+
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'agentcomm-shim-'));
+    try {
+      const r = await new Promise<{ code: number; stdout: string }>((resolve, reject) => {
+        const child = spawn(shim, ['register', '--as', 'shimtest', '--json'], {
+          cwd: dir,
+          env: {
+            PATH: process.env.PATH,
+            HOME: process.env.HOME,
+            AGENTCOMM_BACKEND: `file://${path.join(dir, '.bus')}`,
+            AGENTCOMM_NO_GIT_PROBE: '1',
+          },
+        });
+        let stdout = '';
+        child.stdout.on('data', (d) => (stdout += d.toString()));
+        child.on('error', reject);
+        child.on('exit', (code) => resolve({ code: code ?? -1, stdout }));
+      });
+      expect(r.code).toBe(0);
+      expect((JSON.parse(r.stdout) as { name: string }).name).toBe('shimtest');
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
Root cause of 'command not found': nothing put agentcomm on PATH (package.json bin needs npm -g; plugin shipped no bin/). Fix: ship bin/agentcomm launcher — Claude Code adds plugin bin/ to PATH (like ctx/rakevet), so bare `agentcomm` works everywhere, no system writes, upgrade-safe. Skill keeps the node-path form as fallback. e2e verifies the launcher from a foreign cwd.