### PR TITLE
Fix Codex plugin module boundary

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "agentcomm",
       "source": "./",
       "description": "Multi-agent mailbox CLI — any git remote is a bus (git+ssh/github/sqlite/s3/gcs/postgres). register/send/inbox/wait/claim/log/channels so Claude coordinates with other agents or sessions; auto-selects the repo bus inside a git repo.",
-      "version": "0.16.3",
+      "version": "0.16.4",
       "author": {
         "name": "Yoni Davidson"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agentcomm",
   "description": "Multi-agent mailbox CLI — any git remote is a bus (git+ssh/github/sqlite/s3/gcs/postgres). register/send/inbox/wait/claim/log/channels so Claude coordinates with other agents or sessions; auto-selects the repo bus inside a git repo.",
-  "version": "0.16.3",
+  "version": "0.16.4",
   "author": {
     "name": "Yoni Davidson",
     "email": "yonidavidson@tabnine.com"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentcomm",
-  "version": "0.3.0",
+  "version": "0.16.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentcomm",
-      "version": "0.3.0",
+      "version": "0.16.4",
       "license": "MIT",
       "bin": {
         "agentcomm": "dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentcomm",
-  "version": "0.16.3",
+  "version": "0.16.4",
   "description": "A tiny mailbox/message bus for AI agents that shell out to one CLI. Pluggable storage backends behind a single Backend interface.",
   "type": "module",
   "license": "MIT",

--- a/plugins/agentcomm/.codex-plugin/plugin.json
+++ b/plugins/agentcomm/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agentcomm",
-  "version": "0.16.3",
+  "version": "0.16.4",
   "description": "Coordinate coding agents and sessions through a shared mailbox backed by Git, local files, SQLite, S3, GCS, or Postgres.",
   "author": {
     "name": "Yoni Davidson",

--- a/plugins/agentcomm/package.json
+++ b/plugins/agentcomm/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "agentcomm-codex-plugin",
+  "version": "0.16.4",
+  "private": true,
+  "type": "module",
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/scripts/sync-codex-plugin.mjs
+++ b/scripts/sync-codex-plugin.mjs
@@ -22,6 +22,20 @@ for (const file of ['lib.mjs', 'midturn-digest.mjs', 'prompt-digest.mjs', 'sessi
 }
 
 const packageJson = JSON.parse(await readFile(path.join(root, 'package.json'), 'utf8'));
+await writeFile(
+  path.join(plugin, 'package.json'),
+  `${JSON.stringify(
+    {
+      name: 'agentcomm-codex-plugin',
+      version: packageJson.version,
+      private: true,
+      type: packageJson.type,
+      engines: packageJson.engines,
+    },
+    null,
+    2,
+  )}\n`,
+);
 const manifestPath = path.join(plugin, '.codex-plugin', 'plugin.json');
 const manifest = JSON.parse(await readFile(manifestPath, 'utf8'));
 manifest.version = packageJson.version;


### PR DESCRIPTION
## Summary

- add a generated `package.json` boundary to the Codex plugin payload with `type: module`
- synchronize the payload's version and Node engine from the root package
- bump agentcomm and both plugin manifests to `0.16.4` so Codex installs the corrected cache entry

## Why

Testing the real merged installation showed Node reparsing the packaged ESM `.js` files because the cached plugin had no package boundary. Newer Node emitted a warning; older supported Node versions may reject those modules. Keeping the same plugin version would also leave existing `0.16.3` caches stale.

## Validation

- `npm run plugin:sync`
- `npm run typecheck`
- Codex plugin validator passed
- isolated marketplace install selected `0.16.4`
- installed packaged CLI and SessionStart hook ran with empty stderr
