### PR TITLE
build: publishable `agentcomm-opencode` npm package (one-liner OpenCode install)

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "plugin:sync": "npm run build && node scripts/sync-plugins.mjs",
+    "publish:opencode": "npm run plugin:sync && npm publish plugins/agentcomm-opencode",
     "dev": "tsx src/cli.ts",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/plugins/agentcomm-opencode/README.md
+++ b/plugins/agentcomm-opencode/README.md
@@ -1,0 +1,43 @@
+# agentcomm-opencode
+
+The [OpenCode](https://opencode.ai) plugin for
+[agentcomm](https://github.com/yonidavidson/agentcomm) — a tiny mailbox /
+message bus for AI agents.
+
+It puts every OpenCode session on the repo's agentcomm bus **in-process** (no
+subprocess): it registers the session, briefs it at start, surfaces unread mail
+before the session goes idle, and keeps long turns reachable. Because
+OpenCode's `session.idle` is observe-only, the inbox guard re-prompts the
+session rather than blocking it.
+
+## Install
+
+Add the plugin to your `opencode.json`. OpenCode resolves each `plugin` entry
+through npm's own installer, so the package name is all you need:
+
+```json
+{
+  "plugin": ["agentcomm-opencode"]
+}
+```
+
+The package ships a prebuilt copy of the agentcomm library, so there is no
+build step and — for the file/git backends — zero runtime dependencies.
+
+Then get the repo on the bus (OpenCode reads `AGENTS.md` natively):
+
+```bash
+npx agentcomm init --harness opencode   # writes AGENTS.md
+```
+
+## What it does
+
+- **Session start** — registers you on the bus and injects a briefing (roster,
+  waiting mail, any teammate asking for help).
+- **Mid-turn** (`tool.execute.after`) — heartbeats and surfaces actionable
+  signals (unread mail, active asks) without derailing the task.
+- **Before idle** (`session.idle`) — if unread mail is waiting, re-prompts the
+  session to read `agentcomm inbox --json` and act before finishing.
+
+See the [main README](https://github.com/yonidavidson/agentcomm#as-an-opencode-plugin)
+for the full picture.

--- a/plugins/agentcomm-opencode/package.json
+++ b/plugins/agentcomm-opencode/package.json
@@ -1,10 +1,34 @@
 {
   "name": "agentcomm-opencode",
   "version": "0.16.8",
-  "private": true,
+  "description": "OpenCode plugin for agentcomm — puts every OpenCode session on the agentcomm message bus (auto-register, inbox guard, mid-turn digests) in-process.",
   "type": "module",
+  "main": "src/plugin.ts",
+  "files": [
+    "src",
+    "dist",
+    "README.md"
+  ],
   "engines": {
     "node": ">=18"
   },
-  "main": "src/plugin.ts"
+  "license": "MIT",
+  "author": "yonidavidson",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/yonidavidson/agentcomm.git",
+    "directory": "plugins/agentcomm-opencode"
+  },
+  "homepage": "https://yonidavidson.github.io/agentcomm/",
+  "keywords": [
+    "opencode",
+    "opencode-plugin",
+    "agentcomm",
+    "ai-agents",
+    "message-bus",
+    "agent-coordination"
+  ],
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/scripts/sync-plugins.mjs
+++ b/scripts/sync-plugins.mjs
@@ -31,16 +31,45 @@ const TARGETS = [
   },
   {
     // OpenCode: imports the library in-process (Bun); ships dist + authored src/.
+    // Publishable to the npm registry so `"plugin": ["agentcomm-opencode"]`
+    // installs with no local checkout — OpenCode resolves plugin entries through
+    // npm's own installer. The tarball carries the compiled library (dist/) so
+    // there is no build step and zero runtime deps for the file/git backends.
     dir: 'agentcomm-opencode',
     pkgName: 'agentcomm-opencode',
     copy: ['dist'],
     hooks: [],
     manifest: null,
-    pkgExtra: { main: 'src/plugin.ts' },
+    pkg: (rootPkg) => ({
+      name: 'agentcomm-opencode',
+      version: rootPkg.version,
+      description:
+        'OpenCode plugin for agentcomm — puts every OpenCode session on the agentcomm message bus (auto-register, inbox guard, mid-turn digests) in-process.',
+      type: rootPkg.type,
+      main: 'src/plugin.ts',
+      files: ['src', 'dist', 'README.md'],
+      engines: rootPkg.engines,
+      license: rootPkg.license,
+      author: rootPkg.author,
+      repository: { ...rootPkg.repository, directory: 'plugins/agentcomm-opencode' },
+      homepage: 'https://yonidavidson.github.io/agentcomm/',
+      keywords: ['opencode', 'opencode-plugin', 'agentcomm', 'ai-agents', 'message-bus', 'agent-coordination'],
+      publishConfig: { access: 'public' },
+    }),
   },
 ];
 
 const rootPkg = JSON.parse(await readFile(path.join(root, 'package.json'), 'utf8'));
+
+// Default package.json for generated (non-published) subtrees: private, minimal.
+const defaultPkg = (t) => ({
+  name: t.pkgName,
+  version: rootPkg.version,
+  private: true,
+  type: rootPkg.type,
+  engines: rootPkg.engines,
+  ...t.pkgExtra,
+});
 
 for (const t of TARGETS) {
   const plugin = path.join(root, 'plugins', t.dir);
@@ -59,11 +88,7 @@ for (const t of TARGETS) {
 
   await writeFile(
     path.join(plugin, 'package.json'),
-    `${JSON.stringify(
-      { name: t.pkgName, version: rootPkg.version, private: true, type: rootPkg.type, engines: rootPkg.engines, ...t.pkgExtra },
-      null,
-      2,
-    )}\n`,
+    `${JSON.stringify(t.pkg ? t.pkg(rootPkg) : defaultPkg(t), null, 2)}\n`,
   );
 
   if (t.manifest) {


### PR DESCRIPTION
## Why

Follow-up to #93. OpenCode resolves every `plugin` config entry through npm's own installer (`@npmcli/arborist`, the same machinery as `npm install`), so publishing the plugin to the registry makes the install a one-liner with no local checkout:

```json
{ "plugin": ["agentcomm-opencode"] }
```

That matches how every documented OpenCode plugin ships (dedicated registry packages).

## What

- **`scripts/sync-plugins.mjs`** — a target can now supply a full `pkg(rootPkg)` builder; the Codex/default path keeps the private, minimal manifest. The OpenCode target generates a **publishable** `package.json`: drops `private`, adds `publishConfig.access: public`, `files: ["src","dist","README.md"]`, description, keywords, `repository.directory`, homepage, license, author.
- **Plugin README** for the npm package page (authored — survives sync).
- **`publish:opencode`** root script: `plugin:sync` then `npm publish plugins/agentcomm-opencode`.

The tarball bundles the compiled library (`dist/`), so there's no build step at install and zero runtime deps for the file/git backends.

## Verification
- `npm pack --dry-run` → `src/plugin.ts` + full `dist/` + `README.md` + clean `package.json`.
- Sync is deterministic (re-run = no diff); typecheck clean; no test asserted the old private manifest.

## Note
This wires up publishing but does **not** publish — `npm publish` needs your registry auth/2FA. After merge, run `npm run publish:opencode` (from an `npm login`'d shell) to make `"plugin": ["agentcomm-opencode"]` live, then I'll flip the README/site install to lead with the one-liner.