### PR TITLE
ci: release workflow — auto-publish agentcomm-opencode to npm on new version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,65 @@
+name: release
+
+# Publishes the OpenCode plugin (`agentcomm-opencode`) to the npm registry so
+# `"plugin": ["agentcomm-opencode"]` works with no local checkout. Publishing
+# is idempotent: the job skips any version already on npm, so it is safe to
+# re-run and only ever ships a genuinely new version.
+#
+# Triggers:
+#   - a published GitHub Release (the normal path — cut a release for the
+#     version in package.json and CI ships it), or
+#   - a manual run (workflow_dispatch), with an optional dry-run that packs
+#     without publishing.
+#
+# Requires repo secret NPM_TOKEN (an npm automation/granular token with
+# publish rights). The root `agentcomm` CLI is intentionally NOT published
+# here — it installs straight from GitHub by design.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Pack only — do not publish'
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  publish-opencode-plugin:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          registry-url: 'https://registry.npmjs.org'
+
+      - run: npm ci
+
+      # build + regenerate plugins/agentcomm-opencode (dist + publishable
+      # package.json) so we publish exactly what the repo would produce.
+      - run: npm run plugin:sync
+
+      - name: Publish agentcomm-opencode (skip if version already on npm)
+        working-directory: plugins/agentcomm-opencode
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          NAME=$(node -p "require('./package.json').name")
+          VERSION=$(node -p "require('./package.json').version")
+          echo "Resolved $NAME@$VERSION"
+          if npm view "$NAME@$VERSION" version >/dev/null 2>&1; then
+            echo "::notice::$NAME@$VERSION already published — skipping."
+          elif [ "${{ inputs.dry_run }}" = "true" ]; then
+            echo "Dry run — packing only."
+            npm pack --dry-run
+          else
+            npm publish
+            echo "::notice::Published $NAME@$VERSION"
+          fi


### PR DESCRIPTION
Follow-up to #94. Adds `.github/workflows/release.yml` so publishing `agentcomm-opencode` is owned by CI/CD, not a manual local step.

## Behavior
- **Triggers:** a published GitHub Release (normal path — cut a release for the version in `package.json` and CI ships it), or a manual `workflow_dispatch` (with an optional dry-run that packs without publishing).
- **Idempotent:** skips any version already on npm (`npm view NAME@VERSION`), so re-runs never error and only genuinely-new versions ship.
- **Build parity:** runs `npm run plugin:sync` first, so it publishes exactly what the repo generates (compiled `dist/` + publishable manifest from #94).

## Required
Repo secret **`NPM_TOKEN`** — an npm automation/granular token with publish rights.

## Not in scope
The root `agentcomm` CLI stays off the registry (installs from GitHub by design); this only publishes the OpenCode plugin.