### PR TITLE
docs: document the network command (site + README)

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ why the security story is *subtraction*: your storage's auth is the bus's auth.
 | `channels`         | List the channels that already exist on the `--backend` store (scans for the agentcomm key layout; needs the driver + credentials). |
 | `purge`            | Delete archived (`read/`) messages older than `--older-than`, and/or registrations idle past `--agents-older-than`. Pending mail is never touched. The daemon runs both automatically (30d / 7d defaults). |
 | `log`              | Read a channel's conversation — pending + archived, time-ordered, **non-consuming**, no `--as` needed. `--thread`, `--limit`. |
+| `network`          | Situation report — who's on the bus now (active vs idle), their status, and recent traffic. Read-only. In Claude Code: `/agentcomm:network`. |
 | `conventions`      | Print the effective team conventions (built-in defaults ⊕ `.agentcomm.json`/`.yaml` override). Static — never connects. |
 
 ### Flags

--- a/docs/index.html
+++ b/docs/index.html
@@ -514,7 +514,43 @@ codex plugin add agentcomm@yonidavidson-plugins">Copy</button>
         <div class="card"><span class="cmd">channels</span><p>List the channels that already exist on a store, with agent counts — ready-to-use URIs.</p></div>
         <div class="card"><span class="cmd">purge</span><p>Trim the archive: delete consumed messages older than <code>--older-than</code>. Pending mail is never touched.</p></div>
         <div class="card"><span class="cmd">log</span><p>Read a channel's whole conversation — time-ordered, non-consuming. Catch up before you speak.</p></div>
+        <div class="card"><span class="cmd">network</span><p>A situation report — who's on the bus right now, active vs idle, their status, and the recent traffic. Read-only. In Claude Code: <code>/agentcomm:network</code>.</p></div>
         <div class="card"><span class="cmd">conventions</span><p>The team's rules: lobby, topic naming, subjects. Defaults in code, overridable via <code>.agentcomm.yaml</code>.</p></div>
+      </div>
+
+      <div class="net-example reveal">
+        <div class="net-head">
+          <span class="cmd">/agentcomm:network</span>
+          <span class="net-sub">the same board in Claude Code — one glance at who's here and what they're on</span>
+        </div>
+        <div class="board net-board">
+          <div class="board-head"><span>agent</span><span>status</span><span>last seen</span></div>
+          <div class="board-row">
+            <span class="board-name"><span class="board-dot on"></span>builder-2</span>
+            <span class="board-status">done: PR #204 (safety-gate re-gate)</span>
+            <span class="board-seen">1m ago</span>
+          </div>
+          <div class="board-row">
+            <span class="board-name"><span class="board-dot on"></span>you (this session)</span>
+            <span class="board-status">reviewing PR #204</span>
+            <span class="board-seen">4m ago</span>
+          </div>
+          <div class="board-row">
+            <span class="board-name"><span class="board-dot"></span>worker-1</span>
+            <span class="board-status idle">idle</span>
+            <span class="board-seen">21m ago</span>
+          </div>
+          <div class="board-row">
+            <span class="board-name"><span class="board-dot"></span>reviewer</span>
+            <span class="board-status idle">idle</span>
+            <span class="board-seen">7d ago</span>
+          </div>
+          <p class="board-foot">
+            Nobody's <strong>blocked</strong> right now — but if a row's status started with
+            <code>blocked:</code>, <code>need:</code>, or <code>help:</code>, the command offers to
+            send them an answer you already know. It never invents agents that aren't on the bus.
+          </p>
+        </div>
       </div>
     </div>
   </section>

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -552,3 +552,18 @@ footer a:hover { color: var(--ink); }
   .board-head, .board-row { grid-template-columns: 130px 1fr; }
   .board-head span:last-child, .board-seen { display: none; }
 }
+
+/* ---- /agentcomm:network — static example board ---- */
+.net-example { max-width: 760px; margin: 40px auto 0; }
+.net-head {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 6px 14px;
+  margin-bottom: 14px;
+}
+.net-head .cmd { font-size: 0.9rem; }
+.net-sub { color: #8494a8; font-size: 0.86rem; font-family: var(--sans); }
+.net-board { margin-top: 0; }
+.net-board .board-foot { border-top: 1px solid rgba(255, 255, 255, 0.06); margin-top: 4px; }
+.net-board .board-foot code { color: var(--line-git); }


### PR DESCRIPTION
Documents `agentcomm network` / the `/agentcomm:network` slash command, which was previously undocumented on the site and in the README command table.

## Changes
- **Site (`docs/`)** — a `network` card in the Commands grid, plus a small static example board rendered in the site's own board styling (generic role names: `builder-2`, `worker-1`, `reviewer`; no real names). The footnote documents the command's distinctive behavior: it flags `blocked:` / `need:` / `help:` statuses and offers a reply, and never invents agents.
- **README** — a `network` row in the command reference table, after `log`.

Docs-only, so no version bump.

## Naming
Kept `network` rather than `bus`: on the site "the bus" already means the *transport* (the git remote / storage), so reusing it for the roster command would be ambiguous. `network` reads as "who's on it right now," and it's already shipped and baked into the committed `CLAUDE.md` convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)