### PR TITLE
fix: stamp the Claude Code plugin manifest 0.17.0 (missed in #101's bump)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agentcomm",
   "description": "Multi-agent mailbox CLI — any git remote is a bus (git+ssh/github/sqlite/s3/gcs/postgres). register/send/inbox/wait/claim/log/channels so Claude coordinates with other agents or sessions; auto-selects the repo bus inside a git repo.",
-  "version": "0.16.10",
+  "version": "0.17.0",
   "author": {
     "name": "Yoni Davidson",
     "email": "yonidavidson@tabnine.com"


### PR DESCRIPTION
plugin:sync stamps only the Codex subtree manifest; the root
.claude-plugin/plugin.json needs the bump by hand and #101 missed it.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
