### PR TITLE
release-cut v2 (commit-free on protected main) + /agentcomm:config command

### DIFF
--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -1,36 +1,42 @@
 name: release-cut
 
-# The one-button release train — designed so an agent (or a human) cuts a
-# full release with a single dispatch and CI does everything:
+# The one-dispatch release train — an agent (or a human) cuts a full release
+# and CI does everything that can be done without touching main:
 #
-#   gh workflow run release-cut.yml -f version=<patch|minor|major|X.Y.Z>
+#   gh workflow run release-cut.yml -f version=current   # or X.Y.Z as a guard
 #
-# Steps, in order: bump the version everywhere it is stamped (package.json,
-# lockfile, .claude-plugin/plugin.json; plugin:sync stamps the Codex subtree),
-# rebuild the committed dist/ + plugin subtrees, point the README's OpenCode
-# install URL at the upcoming tarball, sanity-test, push one release commit
-# to main, tag it, publish the GitHub Release with generated notes, and
-# dispatch the tarball-attach workflow (release.yml).
+# main is branch-protected (required check: test), so this workflow is
+# deliberately COMMIT-FREE on main: version bumps land in normal PRs first
+# (npm version + .claude-plugin/plugin.json + `npm run plugin:sync`, all
+# committed — the repo's existing convention), and release-cut releases the
+# tree main already carries:
 #
-# Two deliberate details:
-# - Passing the version main ALREADY carries skips the bump and just tags +
-#   releases the current tree — for cutting a release after a manual bump.
-# - The tarball attach is an explicit `gh workflow run`, not a `release:
-#   published` trigger: events created with the built-in GITHUB_TOKEN never
-#   start other workflows, so relying on the event would silently skip the
-#   tarball. workflow_dispatch is exempt from that guard.
+#   1. preflight — all three version stamps agree, the tag doesn't exist yet
+#   2. sanity    — typecheck + tests (docker-backed suites self-skip here;
+#                  the required `test` check already ran on every merge)
+#   3. tag + GitHub Release with generated notes
+#   4. dispatch release.yml to attach the OpenCode tarball (explicit
+#      dispatch: events created with the built-in GITHUB_TOKEN never start
+#      `release: published` workflows on their own)
+#   5. open the docs PR bumping the OpenCode tarball URL in README + site
+#      (versioned URLs are load-bearing: OpenCode caches by URL, so the
+#      version in the URL is the upgrade trigger). CI does not run on
+#      bot-created PRs — merge it with `gh pr merge --admin`. Best-effort:
+#      if PR creation is disallowed, the release still stands and the log
+#      says what to bump by hand.
 
 on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'patch | minor | major | explicit X.Y.Z'
+        description: 'Guard: the X.Y.Z main should carry, or "current" to release package.json as-is'
         required: true
-        default: 'patch'
+        default: 'current'
 
 permissions:
   contents: write
   actions: write # dispatches release.yml for the tarball attach
+  pull-requests: write # opens the docs URL-bump PR
 
 concurrency: release-cut
 
@@ -41,6 +47,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: main
+          fetch-depth: 0 # tags, for the preflight collision check
 
       - uses: actions/setup-node@v4
         with:
@@ -49,66 +56,65 @@ jobs:
 
       - run: npm ci
 
-      - name: Resolve the target version (bump unless main already carries it)
+      - name: Preflight — stamps agree, tag is free
         id: version
+        env:
+          GUARD: ${{ inputs.version }}
         run: |
-          CURRENT=$(node -p "require('./package.json').version")
-          TARGET="${{ inputs.version }}"
-          if [ "$TARGET" = "$CURRENT" ]; then
-            VERSION="$CURRENT"
-            echo "::notice::main already at $CURRENT — tagging + releasing the current tree, no bump"
-          else
-            VERSION=$(npm version "$TARGET" --no-git-tag-version | tr -d 'v[:space:]')
+          VERSION=$(node -p "require('./package.json').version")
+          if [ "$GUARD" != "current" ] && [ "$GUARD" != "$VERSION" ]; then
+            echo "::error::main carries $VERSION but the dispatch asked for $GUARD — land the bump PR first (release-cut never commits to main)."
+            exit 1
+          fi
+          CLAUDE=$(node -p "require('./.claude-plugin/plugin.json').version")
+          CODEX=$(node -p "require('./plugins/agentcomm/.codex-plugin/plugin.json').version")
+          if [ "$CLAUDE" != "$VERSION" ] || [ "$CODEX" != "$VERSION" ]; then
+            echo "::error::version stamps disagree — package $VERSION, claude plugin $CLAUDE, codex plugin $CODEX. Fix with a bump PR (npm version + stamp .claude-plugin/plugin.json + npm run plugin:sync)."
+            exit 1
+          fi
+          if git rev-parse -q --verify "refs/tags/v${VERSION}" >/dev/null; then
+            echo "::error::tag v${VERSION} already exists — bump the version before releasing."
+            exit 1
           fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
-      - name: Stamp manifests + rebuild the committed artifacts
-        env:
-          VERSION: ${{ steps.version.outputs.version }}
-        run: |
-          node -e '
-            const fs = require("fs");
-            const f = ".claude-plugin/plugin.json";
-            const j = JSON.parse(fs.readFileSync(f, "utf8"));
-            j.version = process.env.VERSION;
-            fs.writeFileSync(f, JSON.stringify(j, null, 2) + "\n");
-          '
-          # builds dist/ and regenerates the Codex plugin subtree (version from package.json)
-          npm run plugin:sync
-
-      - name: Point the README at the upcoming OpenCode tarball
-        env:
-          VERSION: ${{ steps.version.outputs.version }}
-        run: |
-          sed -E -i "s|releases/download/v[0-9]+\.[0-9]+\.[0-9]+/agentcomm-opencode-[0-9]+\.[0-9]+\.[0-9]+\.tgz|releases/download/v${VERSION}/agentcomm-opencode-${VERSION}.tgz|g" README.md
-
-      - name: Sanity (typecheck + tests; docker-backed suites self-skip here)
+      - name: Sanity (typecheck + tests)
         run: |
           npm run typecheck
           npm test
 
-      - name: Commit, tag, push
-        env:
-          VERSION: ${{ steps.version.outputs.version }}
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add -A
-          git commit -m "release: v${VERSION}" || echo "tree already at v${VERSION} — tagging as-is"
-          git tag "v${VERSION}"
-          git push origin main "refs/tags/v${VERSION}"
-
-      - name: Publish the GitHub Release
+      - name: Tag + publish the GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
           VERSION: ${{ steps.version.outputs.version }}
         run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag "v${VERSION}"
+          git push origin "refs/tags/v${VERSION}"
           gh release create "v${VERSION}" --title "v${VERSION}" --generate-notes --verify-tag
 
       - name: Attach the OpenCode tarball (explicit dispatch — see header)
         env:
           GH_TOKEN: ${{ github.token }}
           VERSION: ${{ steps.version.outputs.version }}
+        run: gh workflow run release.yml -f tag="v${VERSION}"
+
+      - name: Open the docs PR (OpenCode tarball URL bump)
+        continue-on-error: true # the release stands even if PR creation is disallowed
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
-          gh workflow run release.yml -f tag="v${VERSION}"
-          echo "::notice::v${VERSION} published — release.yml dispatched to attach agentcomm-opencode-${VERSION}.tgz"
+          sed -E -i "s|releases/download/v[0-9]+\.[0-9]+\.[0-9]+/agentcomm-opencode-[0-9]+\.[0-9]+\.[0-9]+\.tgz|releases/download/v${VERSION}/agentcomm-opencode-${VERSION}.tgz|g" README.md docs/index.html
+          if git diff --quiet; then
+            echo "::notice::docs already point at v${VERSION} — no PR needed"
+            exit 0
+          fi
+          BRANCH="release-docs-v${VERSION}"
+          git checkout -b "$BRANCH"
+          git commit -am "docs: point the OpenCode install URL at v${VERSION}"
+          git push origin "$BRANCH"
+          gh pr create --title "docs: OpenCode tarball URL → v${VERSION}" \
+            --body "Follow-up from the v${VERSION} release-cut. CI does not run on bot-created PRs — merge with \`gh pr merge --admin --squash\`." \
+            || echo "::warning::could not open the docs PR — bump the tarball URL to v${VERSION} in README.md and docs/index.html manually"

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ why the security story is *subtraction*: your storage's auth is the bus's auth.
 | `purge`            | Delete archived (`read/`) messages older than `--older-than`, and/or telemetry events older than `--events` (or the config's `telemetry.retention`). Pending mail is never touched; registrations are **never** purged (presence is heartbeat-derived, and telemetry events reference them). The daemon trims the archive automatically (30d default). |
 | `log`              | Read a channel's conversation — pending + archived, time-ordered, **non-consuming**, no `--as` needed. `--thread`, `--limit`. |
 | `network`          | Situation report — who's on the bus now (active vs idle), their status, and recent traffic. Read-only. In Claude Code: `/agentcomm:network`. |
-| `conventions`      | Print the effective team conventions (built-in defaults ⊕ `.agentcomm.json`/`.yaml` override). Static — never connects. |
+| `conventions`      | Print the effective team conventions (built-in defaults ⊕ `.agentcomm.json`/`.yaml` override). Static — never connects. In Claude Code, `/agentcomm:config` explains and edits the whole config file interactively. |
 | `emit`             | Record a [telemetry event](#telemetry-events--the-append-only-lane) (`--type`, `--name`, `--ref`, `--attrs '<json>'`). Spools locally and rides the next bus write; `--flush` ships now. Inert unless the repo config opts in. |
 | `events`           | Read telemetry events (`--type`/`--name`/`--ref`/`--since <dur>`/`--limit`; `--json` for analysis). |
 
@@ -578,18 +578,22 @@ all seven backends are exercised end-to-end.
 
 ### Releasing
 
-One dispatch does the whole train — bump every stamped version (package,
-lockfile, Claude Code + Codex plugin manifests), rebuild the committed
-`dist/` and plugin subtrees, retarget the README's OpenCode tarball URL,
-sanity-test, push the release commit, tag, publish the GitHub Release with
-generated notes, and attach the OpenCode tarball:
+Two moves. First the version bump lands as a normal PR (main is protected,
+so this rides the required CI check like any change): `npm version X.Y.Z
+--no-git-tag-version`, stamp `.claude-plugin/plugin.json` to match, and
+`npm run plugin:sync` (rebuilds `dist/` and stamps the Codex subtree) — all
+committed. Then one dispatch releases the tree `main` carries:
 
 ```bash
-gh workflow run release-cut.yml -f version=patch   # or minor | major | X.Y.Z
+gh workflow run release-cut.yml -f version=current   # or X.Y.Z as a guard
 ```
 
-Passing the version `main` already carries skips the bump and releases the
-current tree (useful after a manual bump landed in a PR).
+The workflow is commit-free on main: it verifies the three version stamps
+agree, sanity-tests, tags, publishes the GitHub Release with generated
+notes, attaches the OpenCode tarball (via `release.yml`), and opens a
+follow-up docs PR bumping the OpenCode install URL (versioned URLs are the
+OpenCode upgrade trigger — it caches by URL). CI doesn't run on bot-created
+PRs; merge that one with `gh pr merge --admin --squash`.
 
 The test suite runs the **same backend-contract and bus tests** against
 every backend (the git suite runs against local bare repos, so its full

--- a/commands/config.md
+++ b/commands/config.md
@@ -1,0 +1,72 @@
+---
+description: Explain and edit this repo's .agentcomm config — backend, conventions, telemetry — without a trip to the README
+argument-hint: (no args, or a question like "track my review skill")
+allowed-tools: Bash(agentcomm conventions:*) Bash(node:*)
+---
+
+The repo's current effective agentcomm configuration:
+
+!`agentcomm conventions --json 2>/dev/null || node "${CLAUDE_PLUGIN_ROOT}/dist/cli.js" conventions --json 2>/dev/null || echo "(agentcomm CLI not reachable)"`
+
+You are helping the user understand and edit their agentcomm config. The
+output above shows what is in effect right now — `source: null` means
+built-in defaults with no config file yet. Answer their question ($ARGUMENTS
+if given), and when they want a change, write or edit the file for them.
+
+## The config file
+
+`.agentcomm.json` (zero-dep) or `.agentcomm.yaml`/`.yml` (needs the optional
+`yaml` package), searched from the working directory upward; `AGENTCOMM_CONFIG`
+names a file explicitly. It is versioned with the repo — reviewable and shared
+like code. Full surface:
+
+```yaml
+# Pin the bus every agent in this repo uses (otherwise: AGENTCOMM_BACKEND >
+# this file > git-remote autodetect > file://./.agentcomm)
+backend: git+ssh://git@github.com/acme/webapp.git
+
+# The social contract — how agents name rooms and label mail
+conventions:
+  lobby: lobby                      # well-known meeting-room channel
+  topicStyle: kebab-case            # "work on x" → channel name style
+  artifactChannels:
+    issue: issue-<n>                # channel bound to issue N
+    pr: pr-<n>                      # channel bound to PR N
+  subjects: [task, ack, done, revision, question, status]
+
+# Telemetry (opt-in BY PRESENCE of this section — without it, emit and the
+# capture hooks are inert). Deterministic: if a rule is listed, it fires.
+telemetry:
+  track:
+    - on: skill                     # skill | merge | session | task
+      match: code-review            # optional name filter; * globs work
+      record: >                     # optional FREE TEXT — injected at session
+        whether it uncovered bugs,  # start so the agent self-reports this
+        findings count, iteration   # outcome via `agentcomm emit`
+    - on: merge
+    - on: session
+  # retention: 180d                 # default keeps everything; purge --events
+  #                                 # or this horizon are the only aging paths
+```
+
+Notes worth relaying when relevant:
+
+- **conventions** merge per-section over the defaults shown above — set only
+  what differs.
+- **telemetry** semantics: `on`/`match` drive the deterministic hooks (skill
+  runs, `git merge`/`gh pr merge`, session start/end, task events);
+  `record:` free text becomes session-start instructions for the model's
+  self-reports (`agentcomm emit --type <on>-outcome --attrs '{...}'`).
+  Events accumulate under `events/` on the bus; `agentcomm events --json`
+  reads them back. Registrations are never purged — events reference them.
+- **Env knobs** (runtime, not the file): `AGENTCOMM_BACKEND` (override bus),
+  `AGENTCOMM_AGENT` (alias), `AGENTCOMM_DAEMON=0` (bypass daemon),
+  `AGENTCOMM_SYNC=1` (durable sends), `AGENTCOMM_POLL_MS` (daemon poll),
+  `AGENTCOMM_PURGE_AFTER_MS` (daemon archive TTL, 30d).
+- After editing, `agentcomm conventions` (no `--json`) is the quick check
+  that the file parses and shows what took effect. JSON needs nothing;
+  YAML needs `npm install yaml`.
+
+When the user asks for something the config cannot express (e.g. per-agent
+permissions, message encryption), say so plainly instead of inventing keys —
+unknown keys are ignored, not errors.

--- a/plugins/agentcomm/skills/agentcomm/SKILL.md
+++ b/plugins/agentcomm/skills/agentcomm/SKILL.md
@@ -68,7 +68,9 @@ verifiable identity, so tell the user to check history if provenance matters.
 `agentcomm network` is the situation report — active vs idle agents, each
 one's status (what it's doing), and recent activity, in one glance. Use it
 to answer "who's here and what are they on?" before coordinating. In Claude
-Code the `/agentcomm:network` slash command shows the same board.
+Code the `/agentcomm:network` slash command shows the same board, and
+`/agentcomm:config` explains/edits the repo's `.agentcomm` config file
+(backend, conventions, telemetry) without a trip to the README.
 
 ## Commands
 

--- a/skills/agentcomm/SKILL.md
+++ b/skills/agentcomm/SKILL.md
@@ -68,7 +68,9 @@ verifiable identity, so tell the user to check history if provenance matters.
 `agentcomm network` is the situation report — active vs idle agents, each
 one's status (what it's doing), and recent activity, in one glance. Use it
 to answer "who's here and what are they on?" before coordinating. In Claude
-Code the `/agentcomm:network` slash command shows the same board.
+Code the `/agentcomm:network` slash command shows the same board, and
+`/agentcomm:config` explains/edits the repo's `.agentcomm` config file
+(backend, conventions, telemetry) without a trip to the README.
 
 ## Commands
 


### PR DESCRIPTION
Two small units heading into v0.17.0:

**release-cut v2** — the first dispatch failed with `GH006: Protected branch update failed` (main requires the `test` check; workflow tokens can't push commits to it). v2 is commit-free on main: preflight (all three version stamps agree, tag free) → sanity (typecheck + tests) → tag + Release with generated notes → dispatch `release.yml` for the OpenCode tarball → follow-up docs PR bumping the tarball URL (kept **versioned** deliberately: OpenCode caches by URL, so the version in the URL is the upgrade trigger — `releases/latest/download` would break upgrades). Version bumps land in normal PRs (existing convention), and the README's Releasing section now documents the two-move flow.

**`/agentcomm:config`** — a plugin command that shows the effective config (`conventions --json`) and carries the full `.agentcomm.json`/`.yaml` reference inline (backend, conventions, telemetry `track`/`record`/`retention`, env knobs), so users configure in-session instead of via the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)