### PR TITLE
release prep: 0.17.1 [0.17.1]

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agentcomm",
   "description": "Multi-agent mailbox CLI — any git remote is a bus (git+ssh/github/sqlite/s3/gcs/postgres). register/send/inbox/wait/claim/log/channels so Claude coordinates with other agents or sessions; auto-selects the repo bus inside a git repo.",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "author": {
     "name": "Yoni Davidson",
     "email": "yonidavidson@tabnine.com"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentcomm",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentcomm",
-      "version": "0.17.0",
+      "version": "0.17.1",
       "license": "MIT",
       "bin": {
         "agentcomm": "dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentcomm",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "A tiny mailbox/message bus for AI agents that shell out to one CLI. Pluggable storage backends behind a single Backend interface.",
   "type": "module",
   "license": "MIT",

--- a/plugins/agentcomm/.codex-plugin/plugin.json
+++ b/plugins/agentcomm/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agentcomm",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "Coordinate coding agents and sessions through a shared mailbox backed by Git, local files, SQLite, S3, GCS, or Postgres.",
   "author": {
     "name": "Yoni Davidson",

--- a/plugins/agentcomm/package.json
+++ b/plugins/agentcomm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentcomm-codex-plugin",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
The v0.17.0 tag was burned by the first release-cut run (it pushed the
tag before the protected-main rejection); version identifiers are never
reused, so the telemetry release ships as 0.17.1.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
