### PR TITLE
docs: OpenCode tarball URL → v0.17.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Get yourself (and this repo) on the bus — takes under a minute:
    coordination contract to `AGENTS.md`.
 3. **If you are OpenCode**, add the plugin tarball from this repo's latest
    [release](https://github.com/yonidavidson/agentcomm/releases) to your
-   `opencode.json` — `"plugin": ["https://github.com/yonidavidson/agentcomm/releases/download/v0.16.10/agentcomm-opencode-0.16.10.tgz"]`.
+   `opencode.json` — `"plugin": ["https://github.com/yonidavidson/agentcomm/releases/download/v0.17.1/agentcomm-opencode-0.17.1.tgz"]`.
    It puts every session on the repo bus in-process. OpenCode reads `AGENTS.md`
    natively, so `agentcomm init --harness opencode` (which writes `AGENTS.md`)
    also onboards it — see [As an OpenCode plugin](#as-an-opencode-plugin).
@@ -120,7 +120,7 @@ the `.tgz` directly, no clone and no npm registry:
 
 ```json
 {
-  "plugin": ["https://github.com/yonidavidson/agentcomm/releases/download/v0.16.10/agentcomm-opencode-0.16.10.tgz"]
+  "plugin": ["https://github.com/yonidavidson/agentcomm/releases/download/v0.17.1/agentcomm-opencode-0.17.1.tgz"]
 }
 ```
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -102,9 +102,9 @@ codex plugin add agentcomm@yonidavidson-plugins">Copy</button>
       </div>
       <div role="tabpanel" data-harness-panel="opencode" hidden>
         <div class="codeblock">
-          <button class="copy-btn" data-copy='{ "plugin": ["https://github.com/yonidavidson/agentcomm/releases/download/v0.16.10/agentcomm-opencode-0.16.10.tgz"] }'>Copy</button>
+          <button class="copy-btn" data-copy='{ "plugin": ["https://github.com/yonidavidson/agentcomm/releases/download/v0.17.1/agentcomm-opencode-0.17.1.tgz"] }'>Copy</button>
           <div class="line">// opencode.json — install the plugin tarball from the latest release</div>
-          <div class="line">{ "plugin": ["…/releases/download/v0.16.10/agentcomm-opencode-0.16.10.tgz"] }</div>
+          <div class="line">{ "plugin": ["…/releases/download/v0.17.1/agentcomm-opencode-0.17.1.tgz"] }</div>
         </div>
       </div>
     </div>
@@ -141,7 +141,7 @@ codex plugin add agentcomm@yonidavidson-plugins">Copy</button>
             </div>
             <div class="codeblock step-code" role="tabpanel" data-harness-panel="opencode" hidden>
               <div class="line">// opencode.json — plugin tarball from the latest release</div>
-              <div class="line">{ "plugin": ["…/releases/download/v0.16.10/agentcomm-opencode-0.16.10.tgz"] }</div>
+              <div class="line">{ "plugin": ["…/releases/download/v0.17.1/agentcomm-opencode-0.17.1.tgz"] }</div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
Follow-up from the v0.17.1 release-cut (branch pushed by the workflow; PR opened manually — the repo doesn't allow Actions to create PRs). CI does not run on this branch's push event, so merge with admin override.

🤖 Generated with [Claude Code](https://claude.com/claude-code)