### PR TITLE
feat(telemetry): `on: agent` trigger — record tracked subagent spawns

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,9 +413,12 @@ telemetry:
 ```
 
 The plugins wire the deterministic layer automatically: Claude Code hooks
-record tracked `skill` runs (PostToolUse on the Skill tool), `merge`
-commands (guarded Bash matcher), and `session` start/end (end also ships
-the spool); Codex and OpenCode record `session` events; and the session
+record tracked `skill` runs (PostToolUse on the Skill tool), `agent`
+subagent spawns (PostToolUse on the Task/Agent tool, matched by
+`subagent_type` — the only signal for skills that run as dedicated
+subagents or set `disable-model-invocation`), `merge` commands (guarded
+Bash matcher), and `session` start/end (end also ships the spool); Codex
+and OpenCode record `session` events; and the session
 briefing injects each rule's `record:` text so the model knows what to
 self-report. The `on`/`match` layer never depends on the model — if it's
 in the config, it fires.

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -71,6 +71,16 @@
         ]
       },
       {
+        "matcher": "Task|Agent",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/telemetry-capture.mjs\"",
+            "timeout": 10
+          }
+        ]
+      },
+      {
         "matcher": "Bash",
         "hooks": [
           {

--- a/hooks/telemetry-capture.mjs
+++ b/hooks/telemetry-capture.mjs
@@ -1,8 +1,9 @@
 #!/usr/bin/env node
 /**
  * Deterministic telemetry capture (issue #100). Harness hooks route lifecycle
- * moments here — PostToolUse (Skill / Bash), SessionStart, SessionEnd,
- * TaskCompleted — and if the repo's .agentcomm config has a matching
+ * moments here — PostToolUse (Skill / Task·Agent subagent spawns / Bash),
+ * SessionStart, SessionEnd, TaskCompleted — and if the repo's .agentcomm
+ * config has a matching
  * `telemetry.track` rule, the event is recorded. No model discretion: if
  * it's in the config, it fires; without the config section, this exits
  * silently. Recording is `agentcomm emit`, which only appends to the local

--- a/hooks/telemetry-capture.mjs
+++ b/hooks/telemetry-capture.mjs
@@ -45,6 +45,14 @@ function deriveEvent() {
     if (skill && tracked('skill', skill)) return { type: 'skill-ran', name: skill };
     return null;
   }
+  // Subagent spawns (Claude Code's Task/Agent tool). Skills that a repo runs
+  // as dedicated subagents — or that set disable-model-invocation and are
+  // therefore invisible to the Skill tool — are only observable here.
+  if (hook === 'PostToolUse' && (input.tool_name === 'Task' || input.tool_name === 'Agent')) {
+    const subagent = input.tool_input?.subagent_type;
+    if (subagent && tracked('agent', subagent)) return { type: 'agent-ran', name: subagent };
+    return null;
+  }
   if (hook === 'PostToolUse' && input.tool_name === 'Bash') {
     const command = String(input.tool_input?.command ?? '');
     if (/(^|[\s;&|(])git\s+merge\b/.test(command) || /(^|[\s;&|(])gh\s+pr\s+merge\b/.test(command)) {

--- a/plugins/agentcomm/hooks/telemetry-capture.mjs
+++ b/plugins/agentcomm/hooks/telemetry-capture.mjs
@@ -1,8 +1,9 @@
 #!/usr/bin/env node
 /**
  * Deterministic telemetry capture (issue #100). Harness hooks route lifecycle
- * moments here — PostToolUse (Skill / Bash), SessionStart, SessionEnd,
- * TaskCompleted — and if the repo's .agentcomm config has a matching
+ * moments here — PostToolUse (Skill / Task·Agent subagent spawns / Bash),
+ * SessionStart, SessionEnd, TaskCompleted — and if the repo's .agentcomm
+ * config has a matching
  * `telemetry.track` rule, the event is recorded. No model discretion: if
  * it's in the config, it fires; without the config section, this exits
  * silently. Recording is `agentcomm emit`, which only appends to the local

--- a/plugins/agentcomm/hooks/telemetry-capture.mjs
+++ b/plugins/agentcomm/hooks/telemetry-capture.mjs
@@ -45,6 +45,14 @@ function deriveEvent() {
     if (skill && tracked('skill', skill)) return { type: 'skill-ran', name: skill };
     return null;
   }
+  // Subagent spawns (Claude Code's Task/Agent tool). Skills that a repo runs
+  // as dedicated subagents — or that set disable-model-invocation and are
+  // therefore invisible to the Skill tool — are only observable here.
+  if (hook === 'PostToolUse' && (input.tool_name === 'Task' || input.tool_name === 'Agent')) {
+    const subagent = input.tool_input?.subagent_type;
+    if (subagent && tracked('agent', subagent)) return { type: 'agent-ran', name: subagent };
+    return null;
+  }
   if (hook === 'PostToolUse' && input.tool_name === 'Bash') {
     const command = String(input.tool_input?.command ?? '');
     if (/(^|[\s;&|(])git\s+merge\b/.test(command) || /(^|[\s;&|(])gh\s+pr\s+merge\b/.test(command)) {

--- a/plugins/agentcomm/skills/agentcomm/SKILL.md
+++ b/plugins/agentcomm/skills/agentcomm/SKILL.md
@@ -217,8 +217,11 @@ If the repo's `.agentcomm.json`/`.yaml` has a `telemetry` section, the bus
 also carries an append-only event lane that answers questions like "how many
 runs of skill X found bugs, and how many iterations before merge":
 
-- **Hooks record the deterministic facts** (a tracked skill ran, a merge
-  happened, a session started) — you don't emit those.
+- **Hooks record the deterministic facts** (a tracked skill ran, a tracked
+  subagent was spawned, a merge happened, a session started) — you don't
+  emit those. Skills that run as dedicated subagents (or set
+  `disable-model-invocation`, hiding them from the Skill tool) are tracked
+  with `on: agent` matching the `subagent_type`.
 - **You self-report outcomes** the hooks can't judge. The session-start
   briefing lists exactly what to record; when one of those moments happens,
   run e.g. `agentcomm emit --type skill-outcome --name <skill> --ref

--- a/skills/agentcomm/SKILL.md
+++ b/skills/agentcomm/SKILL.md
@@ -217,8 +217,11 @@ If the repo's `.agentcomm.json`/`.yaml` has a `telemetry` section, the bus
 also carries an append-only event lane that answers questions like "how many
 runs of skill X found bugs, and how many iterations before merge":
 
-- **Hooks record the deterministic facts** (a tracked skill ran, a merge
-  happened, a session started) — you don't emit those.
+- **Hooks record the deterministic facts** (a tracked skill ran, a tracked
+  subagent was spawned, a merge happened, a session started) — you don't
+  emit those. Skills that run as dedicated subagents (or set
+  `disable-model-invocation`, hiding them from the Skill tool) are tracked
+  with `on: agent` matching the `subagent_type`.
 - **You self-report outcomes** the hooks can't judge. The session-start
   briefing lists exactly what to record; when one of those moments happens,
   run e.g. `agentcomm emit --type skill-outcome --name <skill> --ref

--- a/test/telemetry-hooks.e2e.test.ts
+++ b/test/telemetry-hooks.e2e.test.ts
@@ -29,6 +29,7 @@ const TELEMETRY = {
   telemetry: {
     track: [
       { on: 'skill', match: 'thermo-*', record: 'whether it uncovered bugs and the findings count' },
+      { on: 'agent', match: 'code-review-*' },
       { on: 'merge' },
       { on: 'session' },
     ],
@@ -119,6 +120,36 @@ describe('telemetry capture hooks (issue #100)', () => {
     );
     cliJson(['register', '--as', 'rider'], dir);
     expect(cliJson<Ev[]>(['events'], dir)).toEqual([]);
+  });
+
+  it('a tracked subagent spawn (Task/Agent tool) is recorded; untracked and typeless ones are not', async () => {
+    const dir = await trackedRepo();
+    // the same subagent skill is unreachable via the Skill tool when it sets
+    // disable-model-invocation — the Task/Agent spawn is the only signal
+    await runHook(
+      'telemetry-capture.mjs',
+      { cwd: dir, hook_event_name: 'PostToolUse', tool_name: 'Task', tool_input: { subagent_type: 'code-review-nuclear' } },
+      dir,
+    );
+    await runHook(
+      'telemetry-capture.mjs',
+      { cwd: dir, hook_event_name: 'PostToolUse', tool_name: 'Agent', tool_input: { subagent_type: 'code-review-nuclear' } },
+      dir,
+    );
+    await runHook(
+      'telemetry-capture.mjs',
+      { cwd: dir, hook_event_name: 'PostToolUse', tool_name: 'Agent', tool_input: { subagent_type: 'general-purpose' } },
+      dir,
+    );
+    await runHook(
+      'telemetry-capture.mjs',
+      { cwd: dir, hook_event_name: 'PostToolUse', tool_name: 'Agent', tool_input: { prompt: 'no subagent_type at all' } },
+      dir,
+    );
+    cliJson(['register', '--as', 'rider'], dir);
+    const events = cliJson<Ev[]>(['events'], dir);
+    expect(events).toHaveLength(2); // both tool spellings fire; untracked/typeless do not
+    for (const e of events) expect(e).toMatchObject({ type: 'agent-ran', name: 'code-review-nuclear', ref: 'feat-x' });
   });
 
   it('a merge command through Bash is recorded when tracked', async () => {


### PR DESCRIPTION
## Why

An `on: skill` track rule can never fire for a skill that runs as a dedicated subagent or sets `disable-model-invocation` — the Skill tool refuses such skills, so no `PostToolUse{tool_name: "Skill"}` ever occurs and the rule silently records nothing. Found in the wild: codota/ctx tracks its `thermo-nuclear-code-quality-review` skill (`disable-model-invocation: true`, runs via `Agent`/`Task` with `subagent_type`) — a review of that config caught the rule as permanently inert, the exact false-green class the telemetry lane exists to expose.

## What

- `hooks/telemetry-capture.mjs`: new branch for `PostToolUse` of the subagent-spawn tool (both the legacy `Task` and current `Agent` spellings) — rules with `on: agent` match `tool_input.subagent_type` and record an `agent-ran` event.
- `hooks/hooks.json` (Claude plugin): `Task|Agent` PostToolUse matcher routing to the capture hook.
- Codex plugin: `.mjs` synced via `scripts/sync-plugins.mjs`; its hand-maintained hooks.json untouched (Codex telemetry stays session-only, as designed).
- README + agentcomm skill doc: document the `agent` trigger and when to use it over `skill`.

## Tests

`test/telemetry-hooks.e2e.test.ts` gains a case covering both directions:

- tracked `subagent_type` via `Task` **and** via `Agent` → two `agent-ran` events with branch `ref` (deleting the new hook branch fails this at 0 events)
- untracked `subagent_type` and a spawn with no `subagent_type` at all → nothing recorded

All 13 telemetry tests pass; typecheck clean. Also verified against a real consumer config (codota/ctx `.agentcomm.json`, merged as codota/ctx#6556): new hook fires `agent-ran`; the pre-trigger 0.17.0 plugin treats the rule as a clean no-op (exit 0, no event).

🤖 Generated with [Claude Code](https://claude.com/claude-code)