### PR TITLE
docs: point the OpenCode install URL at v0.17.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Get yourself (and this repo) on the bus — takes under a minute:
    coordination contract to `AGENTS.md`.
 3. **If you are OpenCode**, add the plugin tarball from this repo's latest
    [release](https://github.com/yonidavidson/agentcomm/releases) to your
-   `opencode.json` — `"plugin": ["https://github.com/yonidavidson/agentcomm/releases/download/v0.17.1/agentcomm-opencode-0.17.1.tgz"]`.
+   `opencode.json` — `"plugin": ["https://github.com/yonidavidson/agentcomm/releases/download/v0.17.2/agentcomm-opencode-0.17.2.tgz"]`.
    It puts every session on the repo bus in-process. OpenCode reads `AGENTS.md`
    natively, so `agentcomm init --harness opencode` (which writes `AGENTS.md`)
    also onboards it — see [As an OpenCode plugin](#as-an-opencode-plugin).
@@ -120,7 +120,7 @@ the `.tgz` directly, no clone and no npm registry:
 
 ```json
 {
-  "plugin": ["https://github.com/yonidavidson/agentcomm/releases/download/v0.17.1/agentcomm-opencode-0.17.1.tgz"]
+  "plugin": ["https://github.com/yonidavidson/agentcomm/releases/download/v0.17.2/agentcomm-opencode-0.17.2.tgz"]
 }
 ```
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -102,9 +102,9 @@ codex plugin add agentcomm@yonidavidson-plugins">Copy</button>
       </div>
       <div role="tabpanel" data-harness-panel="opencode" hidden>
         <div class="codeblock">
-          <button class="copy-btn" data-copy='{ "plugin": ["https://github.com/yonidavidson/agentcomm/releases/download/v0.17.1/agentcomm-opencode-0.17.1.tgz"] }'>Copy</button>
+          <button class="copy-btn" data-copy='{ "plugin": ["https://github.com/yonidavidson/agentcomm/releases/download/v0.17.2/agentcomm-opencode-0.17.2.tgz"] }'>Copy</button>
           <div class="line">// opencode.json — install the plugin tarball from the latest release</div>
-          <div class="line">{ "plugin": ["…/releases/download/v0.17.1/agentcomm-opencode-0.17.1.tgz"] }</div>
+          <div class="line">{ "plugin": ["…/releases/download/v0.17.2/agentcomm-opencode-0.17.2.tgz"] }</div>
         </div>
       </div>
     </div>
@@ -141,7 +141,7 @@ codex plugin add agentcomm@yonidavidson-plugins">Copy</button>
             </div>
             <div class="codeblock step-code" role="tabpanel" data-harness-panel="opencode" hidden>
               <div class="line">// opencode.json — plugin tarball from the latest release</div>
-              <div class="line">{ "plugin": ["…/releases/download/v0.17.1/agentcomm-opencode-0.17.1.tgz"] }</div>
+              <div class="line">{ "plugin": ["…/releases/download/v0.17.2/agentcomm-opencode-0.17.2.tgz"] }</div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
The release train published v0.17.2 but its docs-PR step failed on the GitHub API rate limit — this is that PR, done by hand (README + website install snippets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)