### PR TITLE
release prep: 0.17.4 [0.17.4]

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agentcomm",
   "description": "Multi-agent mailbox CLI \u2014 any git remote is a bus (git+ssh/github/sqlite/s3/gcs/postgres). register/send/inbox/wait/claim/log/channels so Claude coordinates with other agents or sessions; auto-selects the repo bus inside a git repo.",
-  "version": "0.17.3",
+  "version": "0.17.4",
   "author": {
     "name": "Yoni Davidson",
     "email": "yonidavidson@tabnine.com"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentcomm",
-  "version": "0.17.3",
+  "version": "0.17.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentcomm",
-      "version": "0.17.3",
+      "version": "0.17.4",
       "license": "MIT",
       "bin": {
         "agentcomm": "dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentcomm",
-  "version": "0.17.3",
+  "version": "0.17.4",
   "description": "A tiny mailbox/message bus for AI agents that shell out to one CLI. Pluggable storage backends behind a single Backend interface.",
   "type": "module",
   "license": "MIT",

--- a/plugins/agentcomm/.codex-plugin/plugin.json
+++ b/plugins/agentcomm/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agentcomm",
-  "version": "0.17.3",
+  "version": "0.17.4",
   "description": "Coordinate coding agents and sessions through a shared mailbox backed by Git, local files, SQLite, S3, GCS, or Postgres.",
   "author": {
     "name": "Yoni Davidson",

--- a/plugins/agentcomm/package.json
+++ b/plugins/agentcomm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentcomm-codex-plugin",
-  "version": "0.17.3",
+  "version": "0.17.4",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Version bump for the release carrying #117 (repo pointer, #119) and `agentcomm version` (#120). Dispatch release-cut after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)