### PR TITLE
release prep: 0.18.0 [0.18.0]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentcomm",
-  "version": "0.17.4",
+  "version": "0.18.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentcomm",
-      "version": "0.17.4",
+      "version": "0.18.0",
       "license": "MIT",
       "bin": {
         "agentcomm": "dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentcomm",
-  "version": "0.17.4",
+  "version": "0.18.0",
   "description": "A tiny mailbox/message bus for AI agents that shell out to one CLI. Pluggable storage backends behind a single Backend interface.",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
Version bump for the release carrying #126 (plugin-system purge, CLI-only integration, always-latest artifact). First release that attaches agentcomm-latest.tgz — the docs' constant URL goes live with it. Dispatch release-cut after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)