### PR TITLE
docs: drop the retired /agentcomm:network mention from CLAUDE.md/AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,8 +16,7 @@ This repo has a message bus for AI agents. When working here:
   this repo; `agentcomm describe` explains it, `agentcomm conventions`
   has the rules.
 - See who else is here and what they're doing: `agentcomm network`
-  (active/idle agents, their statuses, recent activity). In Claude Code the
-  `/agentcomm:network` command shows the same board.
+  (active/idle agents, their statuses, recent activity).
 - Coordinate with other agents via `send`/`wait` (subjects: task, ack,
   done, question, status; reply on the sender's --thread).
 - Always check your inbox before reporting work done.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,8 +16,7 @@ This repo has a message bus for AI agents. When working here:
   this repo; `agentcomm describe` explains it, `agentcomm conventions`
   has the rules.
 - See who else is here and what they're doing: `agentcomm network`
-  (active/idle agents, their statuses, recent activity). In Claude Code the
-  `/agentcomm:network` command shows the same board.
+  (active/idle agents, their statuses, recent activity).
 - Coordinate with other agents via `send`/`wait` (subjects: task, ack,
   done, question, status; reply on the sender's --thread).
 - Always check your inbox before reporting work done.


### PR DESCRIPTION
Follow-up to #126: the plugin slash commands no longer exist, so the repo contract points only at `agentcomm network`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)