### PR TITLE
feat: OpenCode telemetry capture parity — tool events + spool flush in the generated hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,13 +140,21 @@ export const AgentcommHooks: Plugin = async ({ directory, client, $ }) => {
       const peek = await sh`agentcomm peek --json`.quiet();
       // …parses the inbox and re-prompts the session when mail is waiting…
     },
+    // Telemetry parity with the other harnesses: tool events are normalized
+    // and handed to `agentcomm hook telemetry`, which owns the repo's
+    // telemetry.track rule matching; dispose() ships the event spool.
+    async 'tool.execute.after'(input) {
+      // …skill / task / bash(merge) → agentcomm hook telemetry…
+    },
+    async dispose() {
+      // …agentcomm emit --flush…
+    },
   };
 };
 ```
 
 That same shape is how you'd wire any other hook to the bus — e.g. a
-`tool.execute.after` handler that runs `agentcomm emit` to record telemetry,
-or a handler that `agentcomm send`s a teammate when a long task finishes.
+handler that `agentcomm send`s a teammate when a long task finishes.
 (OpenCode's `session.idle` can't block, so its inbox guard nudges instead of
 holding the session the way the Claude Code stop guard does.)
 
@@ -450,16 +458,19 @@ telemetry:
   # retention: 180d      # opt-in; default keeps everything
 ```
 
-The generated hooks wire the deterministic layer automatically: Claude Code
-records tracked `skill` runs (PostToolUse on the Skill tool), `agent`
-subagent spawns (PostToolUse on the Task/Agent tool, matched by
-`subagent_type` — the only signal for skills that run as dedicated
-subagents or set `disable-model-invocation`), `merge` commands (guarded
-Bash matcher), and `session` start/end (end also ships the spool); Codex
-and OpenCode record `session` events; and the session
-briefing injects each rule's `record:` text so the model knows what to
-self-report. The `on`/`match` layer never depends on the model — if it's
-in the config, it fires.
+The generated hooks wire the deterministic layer automatically, and capture
+is identical across Claude Code, Codex, and OpenCode — the config is the
+only knob: tracked `skill` runs (the Skill/skill tool), `agent` subagent
+spawns (the Task/task tool, matched by `subagent_type` — the only signal
+for skills that run as dedicated subagents or set
+`disable-model-invocation`), `merge` commands (guarded Bash matcher), and
+`session` start/end (end also ships the spool via a bare
+`agentcomm emit --flush`). The harness payloads are normalized and handed
+to `agentcomm hook telemetry`, so the rule matching lives in the CLI once;
+the session briefing injects each rule's `record:` text so the model knows
+what to self-report. The `on`/`match` layer never depends on the model —
+if it's in the config, it fires. (Only task-list tracking differs: Codex
+and OpenCode have no task events.)
 
 Recording is free at capture time: `agentcomm emit --type skill-outcome
 --name my-review-skill --ref "$(git branch --show-current)" --attrs

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -113,6 +113,7 @@ Flags:
   --ref <text>             emit/events: correlation handle (branch, PR#, run id)
   --attrs <json>           emit: free-form JSON payload for the event
   --flush                  emit: ship the spool now instead of riding the next write
+                           (bare --flush ships it without recording a new event)
   --since <dur>            events: only events newer than e.g. 30d, 12h
   --events <dur>           purge: age out telemetry events older than this
   --json                   Machine-readable JSON output
@@ -793,11 +794,30 @@ import type { Plugin } from '@opencode-ai/plugin';
 export const AgentcommHooks: Plugin = async ({ directory, client, $ }) => {
   const sh = $.cwd(directory).nothrow();
 
+  // Telemetry parity with Claude Code/Codex: normalize the harness payload
+  // and hand it to the CLI, which owns the repo's telemetry.track rule
+  // matching (inert without a telemetry config).
+  const telemetry = (payload: Record<string, unknown>) =>
+    sh\`echo \${JSON.stringify(payload)} | agentcomm hook telemetry\`.quiet();
+
   // Session start: register on the repo bus (auto-detected from the git
   // remote) under a session-unique alias.
   await sh\`agentcomm register --status "opencode session"\`.quiet();
+  await telemetry({ hook_event_name: 'SessionStart' });
 
   return {
+    // Tracked tool events → the CLI's rule matcher. Only the tools the rules
+    // can name; bash is pre-filtered so ordinary commands never spawn a CLI.
+    async 'tool.execute.after'(input) {
+      const args = (input as { args?: Record<string, unknown> }).args ?? {};
+      if (input.tool === 'skill' && typeof args.name === 'string') {
+        await telemetry({ hook_event_name: 'PostToolUse', tool_name: 'Skill', tool_input: { skill: args.name } });
+      } else if (input.tool === 'task' && typeof args.subagent_type === 'string') {
+        await telemetry({ hook_event_name: 'PostToolUse', tool_name: 'Task', tool_input: { subagent_type: args.subagent_type } });
+      } else if (input.tool === 'bash' && typeof args.command === 'string' && args.command.includes('merge')) {
+        await telemetry({ hook_event_name: 'PostToolUse', tool_name: 'Bash', tool_input: { command: args.command } });
+      }
+    },
     // OpenCode's session.idle can't block, so the inbox guard degrades to a
     // nudge: unread mail re-prompts the session instead of holding it open.
     async event({ event }) {
@@ -825,6 +845,12 @@ export const AgentcommHooks: Plugin = async ({ directory, client, $ }) => {
           },
         })
         .catch(() => {});
+    },
+
+    // Session end is the last chance to ship the local event spool.
+    async dispose() {
+      await telemetry({ hook_event_name: 'SessionEnd' });
+      await sh\`agentcomm emit --flush\`.quiet();
     },
   };
 };
@@ -1276,7 +1302,21 @@ async function cmdEmit(cfg: ResolvedConfig, flags: ParsedFlags): Promise<number>
     return 0;
   }
   if (!flags.type) {
-    fail('emit requires --type <event-type>, e.g. emit --type skill-outcome --name my-skill --attrs \'{"found_bugs":true}\'');
+    if (!flags.flush) {
+      fail('emit requires --type <event-type> (or a bare --flush to ship the spool), e.g. emit --type skill-outcome --name my-skill --attrs \'{"found_bugs":true}\'');
+    }
+    // Bare --flush: ship whatever is spooled without recording a new event —
+    // the generated hooks' last-chance flush at session end.
+    const me = await resolveAgent(cfg);
+    const backend = await resolveTransport(cfg, flags);
+    try {
+      const shipped = await flushEvents(backend, cfg.backendUri, me);
+      if (cfg.json) emit({ spooled: false, flushed: shipped });
+      else process.stdout.write(`shipped ${shipped} spooled event(s)\n`);
+    } finally {
+      await backend.close?.();
+    }
+    return 0;
   }
   let attrs: Record<string, unknown> | undefined;
   if (flags.attrs !== undefined) {

--- a/test/hooks-cmd.e2e.test.ts
+++ b/test/hooks-cmd.e2e.test.ts
@@ -57,6 +57,14 @@ describe('CLI hooks (harness hook generation)', () => {
     expect(content).toContain('agentcomm peek --json');
     expect(content).toContain("event.type !== 'session.idle'");
     expect(content).toContain("from '@opencode-ai/plugin'");
+    // Telemetry parity (#115): tool events feed the CLI's rule matcher, and
+    // dispose ships the spool. Matching stays CLI-side — the template only
+    // normalizes payloads.
+    expect(content).toContain('agentcomm hook telemetry');
+    expect(content).toContain("'tool.execute.after'");
+    for (const tool of ['skill', 'task', 'bash']) expect(content).toContain(`input.tool === '${tool}'`);
+    expect(content).toContain('agentcomm emit --flush');
+    expect(content).toContain('async dispose()');
   });
 
   it('never overwrites an existing (possibly user-edited) hooks file', async () => {

--- a/test/telemetry.e2e.test.ts
+++ b/test/telemetry.e2e.test.ts
@@ -138,6 +138,22 @@ describe('telemetry events (issue #100)', () => {
     expect(await eventBlobs(dir)).toHaveLength(1);
   });
 
+  it('bare emit --flush ships the spool without recording a new event', async () => {
+    const { dir, run } = await mkCtx({ track: [{ on: 'skill' }] });
+    await run(['emit', '--type', 'skill-ran', '--name', 's', '--as', 'bob', '--json']);
+    expect(await eventBlobs(dir)).toHaveLength(0); // spooled only, nothing shipped yet
+
+    const r = await run(['emit', '--flush', '--as', 'bob', '--json']);
+    expect(r.code).toBe(0);
+    expect(JSON.parse(r.stdout)).toMatchObject({ spooled: false, flushed: 1 });
+    expect(await eventBlobs(dir)).toHaveLength(1);
+
+    // an empty spool flushes to nothing, still exit 0
+    const again = await run(['emit', '--flush', '--as', 'bob', '--json']);
+    expect(again.code).toBe(0);
+    expect(JSON.parse(again.stdout)).toMatchObject({ spooled: false, flushed: 0 });
+  });
+
   it('emit validates its inputs', async () => {
     const { run } = await mkCtx({ track: [] });
     const noType = await run(['emit', '--name', 'x', '--as', 'alice']);


### PR DESCRIPTION
Closes #115 (and #129 item 2).

## What
- **Generated OpenCode hooks** (`.opencode/plugin/agentcomm.ts` template in `src/cli.ts`):
  - `tool.execute.after` normalizes `skill` / `task` / `bash` tool payloads into the same stdin JSON shape the other harnesses send and pipes them to `agentcomm hook telemetry` — rule matching stays CLI-side, one implementation for all three harnesses. Bash is pre-filtered (`command.includes('merge')`) so ordinary commands never spawn a CLI, mirroring the guarded Bash matcher in the Claude/Codex configs.
  - Session start/end forwarded the same way (`SessionStart` after register, `SessionEnd` in `dispose()`).
  - `dispose()` also runs a best-effort bare `agentcomm emit --flush` — the last chance to ship the spool even when `on: session` isn't tracked.
- **CLI**: `emit --flush` without `--type` is now a flush-only mode (ship the spool, record nothing). Previously it errored, which made the dispose-flush impossible.
- **README**: telemetry section now states capture is identical across the three harnesses; OpenCode example updated to show the new handlers.

## Verification
- Full suite: 258 passed, 6 skipped (heavy backends self-skip).
- New test: bare `emit --flush` ships a spooled event without recording a new one (and is a 0-flush no-op on an empty spool).
- Extended the `hooks --harness opencode` test to assert the telemetry wiring.
- Generated file typechecked standalone with `tsc --strict` against the real `@opencode-ai/plugin` types (input of `tool.execute.after` includes `args` since 1.x; on older runtimes the handlers no-op — fail open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)