### PR TITLE
fix(site): show the full install URL instead of an ellipsis

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -89,7 +89,7 @@
         <div class="codeblock">
           <button class="copy-btn" data-copy="npm install -g https://github.com/yonidavidson/agentcomm/releases/latest/download/agentcomm-latest.tgz
 agentcomm hooks --harness claude">Copy</button>
-          <div class="line">$ npm install -g …/releases/latest/download/agentcomm-latest.tgz</div>
+          <div class="line">$ npm install -g https://github.com/yonidavidson/agentcomm/releases/latest/download/agentcomm-latest.tgz</div>
           <div class="line">$ agentcomm hooks --harness claude</div>
         </div>
       </div>
@@ -97,7 +97,7 @@ agentcomm hooks --harness claude">Copy</button>
         <div class="codeblock">
           <button class="copy-btn" data-copy="npm install -g https://github.com/yonidavidson/agentcomm/releases/latest/download/agentcomm-latest.tgz
 agentcomm hooks --harness codex">Copy</button>
-          <div class="line">$ npm install -g …/releases/latest/download/agentcomm-latest.tgz</div>
+          <div class="line">$ npm install -g https://github.com/yonidavidson/agentcomm/releases/latest/download/agentcomm-latest.tgz</div>
           <div class="line">$ agentcomm hooks --harness codex</div>
         </div>
       </div>
@@ -105,7 +105,7 @@ agentcomm hooks --harness codex">Copy</button>
         <div class="codeblock">
           <button class="copy-btn" data-copy="npm install -g https://github.com/yonidavidson/agentcomm/releases/latest/download/agentcomm-latest.tgz
 agentcomm hooks --harness opencode">Copy</button>
-          <div class="line">$ npm install -g …/releases/latest/download/agentcomm-latest.tgz</div>
+          <div class="line">$ npm install -g https://github.com/yonidavidson/agentcomm/releases/latest/download/agentcomm-latest.tgz</div>
           <div class="line">$ agentcomm hooks --harness opencode</div>
         </div>
       </div>
@@ -134,15 +134,15 @@ agentcomm hooks --harness opencode">Copy</button>
               <button type="button" role="tab" aria-selected="false" data-harness-tab="opencode">OpenCode</button>
             </div>
             <div class="codeblock step-code" role="tabpanel" data-harness-panel="claude">
-              <div class="line">$ npm install -g …/releases/latest/download/agentcomm-latest.tgz</div>
+              <div class="line">$ npm install -g https://github.com/yonidavidson/agentcomm/releases/latest/download/agentcomm-latest.tgz</div>
               <div class="line">$ agentcomm hooks --harness claude</div>
             </div>
             <div class="codeblock step-code" role="tabpanel" data-harness-panel="codex" hidden>
-              <div class="line">$ npm install -g …/releases/latest/download/agentcomm-latest.tgz</div>
+              <div class="line">$ npm install -g https://github.com/yonidavidson/agentcomm/releases/latest/download/agentcomm-latest.tgz</div>
               <div class="line">$ agentcomm hooks --harness codex</div>
             </div>
             <div class="codeblock step-code" role="tabpanel" data-harness-panel="opencode" hidden>
-              <div class="line">$ npm install -g …/releases/latest/download/agentcomm-latest.tgz</div>
+              <div class="line">$ npm install -g https://github.com/yonidavidson/agentcomm/releases/latest/download/agentcomm-latest.tgz</div>
               <div class="line">$ agentcomm hooks --harness opencode</div>
             </div>
           </div>
@@ -665,7 +665,7 @@ agentcomm hooks --harness opencode">Copy</button>
             <div class="codeblock">
               <button class="copy-btn" data-copy="npm install -g https://github.com/yonidavidson/agentcomm/releases/latest/download/agentcomm-latest.tgz
 agentcomm hooks --harness claude">Copy</button>
-              <div class="line">$ npm install -g …/releases/latest/download/agentcomm-latest.tgz</div>
+              <div class="line">$ npm install -g https://github.com/yonidavidson/agentcomm/releases/latest/download/agentcomm-latest.tgz</div>
               <div class="line">$ agentcomm hooks --harness claude</div>
             </div>
           </div>
@@ -673,7 +673,7 @@ agentcomm hooks --harness claude">Copy</button>
             <div class="codeblock">
               <button class="copy-btn" data-copy="npm install -g https://github.com/yonidavidson/agentcomm/releases/latest/download/agentcomm-latest.tgz
 agentcomm hooks --harness codex">Copy</button>
-              <div class="line">$ npm install -g …/releases/latest/download/agentcomm-latest.tgz</div>
+              <div class="line">$ npm install -g https://github.com/yonidavidson/agentcomm/releases/latest/download/agentcomm-latest.tgz</div>
               <div class="line">$ agentcomm hooks --harness codex</div>
             </div>
           </div>
@@ -681,7 +681,7 @@ agentcomm hooks --harness codex">Copy</button>
             <div class="codeblock">
               <button class="copy-btn" data-copy="npm install -g https://github.com/yonidavidson/agentcomm/releases/latest/download/agentcomm-latest.tgz
 agentcomm hooks --harness opencode">Copy</button>
-              <div class="line">$ npm install -g …/releases/latest/download/agentcomm-latest.tgz</div>
+              <div class="line">$ npm install -g https://github.com/yonidavidson/agentcomm/releases/latest/download/agentcomm-latest.tgz</div>
               <div class="line">$ agentcomm hooks --harness opencode</div>
             </div>
           </div>


### PR DESCRIPTION
User report: the install command on the website displays `npm install -g …/releases/latest/download/agentcomm-latest.tgz` — the ellipsis reads as a relative path and the command fails for anyone who types what they see instead of using the Copy button. Replaced with the full URL in all 9 codeblock lines (hero + install section, all three harness tabs). The codeblock CSS already wraps long lines safely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)