### PR TITLE
docs(cli): agent quickstart + self-update story in the main help

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -24,6 +24,15 @@ const USAGE = `agentcomm — a tiny mailbox/message bus for AI agents
 Usage:
   agentcomm <command> [args] [flags]
 
+Agent quickstart (if you are an AI agent):
+  agentcomm version                                   # once per session — prints the upgrade command when you're behind
+  agentcomm register --status "<what you're doing>"   # join the bus + declare your task
+  agentcomm inbox --json                              # consume instructions that may be waiting
+  agentcomm network                                   # who else is here, what they're doing
+  agentcomm send <to> "<body>"  ·  agentcomm wait     # coordinate — reply on the sender's --thread
+  Re-check your inbox before reporting your task done.
+  Full etiquette: agentcomm conventions · bus semantics: agentcomm describe
+
 Commands:
   init                     Put this repo on the bus: writes agent instructions
                            for --harness claude|codex|opencode|agents
@@ -79,7 +88,9 @@ Commands:
                            use it automatically
   version                  Installed version + the latest GitHub release,
                            compared — prints the npm install -g one-liner
-                           when an update exists (also -v / --version).
+                           when an update exists (also -v / --version);
+                           --json returns {version, latest, upToDate,
+                           install} (install only when behind).
                            Agents: run this once per session to stay current
 
 Flags:
@@ -133,6 +144,13 @@ Env:
                              import before resolving --backend, so a
                              third-party package can register a new URI
                              scheme via registerBackend() (see README)
+
+Updates:
+  No harness auto-upgrades a globally installed CLI. In a hook-wired session
+  agentcomm compares itself against the latest release once a day and prints
+  a one-line upgrade notice; everywhere else \`agentcomm version\` is the
+  explicit check — it prints the exact upgrade command when this install is
+  behind, and its --json output is the machine contract for scripts.
 
 Examples:
   agentcomm register --as alice --backend sqlite:///tmp/bus.db

--- a/test/help.e2e.test.ts
+++ b/test/help.e2e.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawn } from 'node:child_process';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const cli = path.join(here, '..', 'src', 'cli.ts');
+
+interface RunResult {
+  code: number;
+  stdout: string;
+  stderr: string;
+}
+
+function run(args: string[]): Promise<RunResult> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, ['--import', 'tsx', cli, ...args], {
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (d) => (stdout += d.toString()));
+    child.stderr.on('data', (d) => (stderr += d.toString()));
+    child.on('error', reject);
+    child.on('exit', (code) => resolve({ code: code ?? -1, stdout, stderr }));
+    child.stdin.end();
+  });
+}
+
+// The bare `--help` is the ONLY onboarding surface for an agent that meets
+// the CLI with no skill, no CLAUDE.md contract, and no harness hooks
+// (issues #135/#136). These assertions guard the two things a cold agent
+// must be able to learn from it: how to behave on the bus, and how to stay
+// current — so a future help rewrite can't silently drop either.
+describe('main help', () => {
+  it('opens with the agent quickstart, before the command reference', async () => {
+    const res = await run(['--help']);
+    expect(res.code).toBe(0);
+    const help = res.stdout;
+
+    const quickstart = help.indexOf('Agent quickstart');
+    expect(quickstart).toBeGreaterThan(-1);
+    expect(quickstart).toBeLessThan(help.indexOf('Commands:'));
+
+    // Drift guard: the same flow the init-written CLAUDE.md/AGENTS.md
+    // contract teaches — register+declare, drain the inbox, see the roster,
+    // re-check before reporting done.
+    const block = help.slice(quickstart, help.indexOf('Commands:'));
+    expect(block).toContain('agentcomm register --status');
+    expect(block).toContain('agentcomm inbox --json');
+    expect(block).toContain('agentcomm network');
+    expect(block).toMatch(/inbox before reporting/);
+
+    // Pointers to the full contract.
+    expect(block).toContain('agentcomm conventions');
+    expect(block).toContain('agentcomm describe');
+  });
+
+  it('surfaces the self-update story: quickstart hint, version --json contract, Updates blurb', async () => {
+    const help = (await run(['--help'])).stdout;
+
+    // Keep-current hint rides the quickstart at the top (#135 cross-linked
+    // from the #136 block).
+    const block = help.slice(help.indexOf('Agent quickstart'), help.indexOf('Commands:'));
+    expect(block).toContain('agentcomm version');
+    expect(block).toMatch(/upgrade command/);
+
+    // The machine contract of `version --json` is documented in its entry.
+    expect(help).toContain('{version, latest, upToDate,');
+
+    // One-place "how updates work" epilogue.
+    expect(help).toContain('Updates:');
+    expect(help).toMatch(/No harness auto-upgrades/);
+  });
+});


### PR DESCRIPTION
## What

The bare `--help` is the entire onboarding surface for an agent that meets the CLI with no skill, no CLAUDE.md contract, and no harness hooks. This PR makes it teach the two things a cold agent can't otherwise learn:

- **Agent quickstart** (#136): an 8-line block above `Commands:` — keep current → register with a status → drain the inbox → see the roster → coordinate → re-check the inbox before reporting done — plus pointers to `agentcomm conventions` (full etiquette) and `agentcomm describe` (bus semantics).
- **Self-update discoverability** (#135): the keep-current hint rides the top of the quickstart; the `version` entry now documents the `--json` machine contract (`{version, latest, upToDate, install}`, `install` only when behind); a short `Updates:` epilogue explains that no harness auto-upgrades a global CLI and `agentcomm version` is the explicit check.

`test/help.e2e.test.ts` asserts the quickstart sits before `Commands:`, mentions the register/inbox/network flow and both pointers, and that the update story (hint + contract + epilogue) survives future help rewrites — the drift-guard option issue #136 offers in lieu of a shared constant (the etiquette prose lives in the init templates, which read differently by design).

Deliberately does **not** quote the install command anywhere — the help points at `agentcomm version`, which sources it from one constant. That keeps this PR independent of the npm-publish work (#137) currently in flight on `npm-publish-sdk`.

Closes #135
Closes #136

🤖 Generated with [Claude Code](https://claude.com/claude-code)