### PR TITLE
release prep: 0.19.0 [0.19.0]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentcomm",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentcomm",
-      "version": "0.18.0",
+      "version": "0.19.0",
       "license": "MIT",
       "bin": {
         "agentcomm": "dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentcomm",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "description": "A tiny mailbox/message bus for AI agents that shell out to one CLI. Pluggable storage backends behind a single Backend interface.",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
Version bump for the first registry-published release — carries #137 (npm publish + SDK story), #135/#136 (agent-onboarding help, merged in #138/#139).

Release plan after merge: bootstrap-publish 0.18.0→registry is NOT needed; instead the flow is: manual first `npm publish` (bootstraps the package on the registry), configure trusted publisher for release.yml on npmjs.com, then `gh workflow run release-cut.yml -f version=current` — its publish-npm job validates the OIDC path end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)