### PR TITLE
chore: regenerate the committed OpenCode hooks post-npm-publish

### DIFF
--- a/.opencode/plugin/agentcomm.ts
+++ b/.opencode/plugin/agentcomm.ts
@@ -2,8 +2,7 @@
 // OpenCode session in this repo joins the bus. Safe to edit; regenerating
 // never overwrites an existing file.
 //
-// Drives the globally installed agentcomm CLI
-// (npm install -g https://github.com/yonidavidson/agentcomm/releases/latest/download/agentcomm-latest.tgz).
+// Drives the globally installed agentcomm CLI (npm install -g agentcomm@latest).
 // Every hook fails open: a broken bus never wedges the session.
 import type { Plugin } from '@opencode-ai/plugin';
 


### PR DESCRIPTION
Follow-up to #133 + #139: the committed `.opencode/plugin/agentcomm.ts` was generated before the registry switch, so its header comment still quoted the release-tarball install URL. Regenerated with `agentcomm hooks --harness opencode` from current main — the diff is the install comment only (`npm install -g agentcomm@latest`).

Landing this before the 0.19.0 cut (#140) lets the fixed file ride the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)