### PR TITLE
fix(release): derive the npm pack filename — scoped package broke the tarball attach

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,13 +79,17 @@ jobs:
         id: pack
         run: |
           VERSION=$(node -p "require('./package.json').version")
-          # `npm pack` emits agentcomm-<version>.tgz (dist-only, per package.json "files").
-          npm pack
+          # `npm pack` emits yonidavidson-agentcomm-<version>.tgz for the
+          # scoped name (dist-only, per package.json "files"); take the
+          # filename from npm itself, then keep the historical asset names —
+          # README documents …/download/vX.Y.Z/agentcomm-X.Y.Z.tgz.
+          PACKED=$(npm pack --silent | tail -1)
           CLI="agentcomm-${VERSION}.tgz"
+          cp "$PACKED" "$CLI"
           # Constant-named copy: GitHub's releases/latest/download/<asset>
           # redirect makes …/releases/latest/download/agentcomm-latest.tgz a
           # stable always-newest URL for scripts and automations.
-          cp "$CLI" agentcomm-latest.tgz
+          cp "$PACKED" agentcomm-latest.tgz
           echo "cli=$CLI" >> "$GITHUB_OUTPUT"
           echo "Packed $CLI ($(du -h "$CLI" | cut -f1))"
 


### PR DESCRIPTION
The v0.19.0 release run failed in `attach-install-tarball`: after #142, `npm pack` emits `yonidavidson-agentcomm-0.19.0.tgz`, but the workflow hardcoded `agentcomm-0.19.0.tgz`. (Its sibling `publish-npm` job succeeded — the already-published guard skipped as designed.)

Fix: take the packed filename from `npm pack --silent`, then copy it to the two historical asset names (`agentcomm-X.Y.Z.tgz`, `agentcomm-latest.tgz`) so the documented constant URL keeps working unchanged.

After merge: re-dispatch `release.yml` with tag v0.19.0 to attach the missing assets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)