### PR TITLE
fix(daemon): bind the socket before warming, warm in one round trip

### DIFF
--- a/src/backends/git.ts
+++ b/src/backends/git.ts
@@ -3,7 +3,7 @@ import { createHash, randomUUID } from 'node:crypto';
 import { promises as fs } from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { type Backend, type Claimable, type Message } from '../types.js';
+import { type Backend, type Claimable, type Message, type Snapshottable } from '../types.js';
 
 /**
  * GitBackend — the generic "commits are the storage" transport, host-agnostic
@@ -34,7 +34,7 @@ import { type Backend, type Claimable, type Message } from '../types.js';
  *   - `claim` is implemented (Claimable) via optimistic CAS — race-free
  *     shared work queues with zero infrastructure.
  */
-export class GitBackend implements Backend, Claimable {
+export class GitBackend implements Backend, Claimable, Snapshottable {
   /** Each poll is a real fetch — cheap against local remotes, a round trip against hosts. */
   readonly pollIntervalMs = 2000;
 
@@ -118,14 +118,37 @@ export class GitBackend implements Backend, Claimable {
     });
   }
 
+  /**
+   * Fetches force-update the same refs/agentcomm/tip, and concurrent ones
+   * collide on its ref lock and fail spuriously — the daemon drives poll,
+   * outbox flusher, and client ops through ONE instance concurrently (issue
+   * #144). In-instance fetches queue here; a collision with another PROCESS
+   * (a --direct CLI sharing the cache repo) is retried below.
+   */
+  private tipChain: Promise<unknown> = Promise.resolve();
+
   /** Fetch the bus branch; its local tip sha, or null when it doesn't exist yet. */
-  private async tip(): Promise<string | null> {
-    try {
-      await this.git(['fetch', '--quiet', 'origin', `+refs/heads/${this.branch}:refs/agentcomm/tip`]);
-    } catch (err) {
-      const stderr = (err as { gitStderr?: string }).gitStderr ?? '';
-      if (/couldn'?t find remote ref|Could not find remote ref/i.test(stderr)) return null;
-      throw err;
+  private tip(): Promise<string | null> {
+    const run = (): Promise<string | null> => this.tipFetch();
+    const next = this.tipChain.then(run, run);
+    this.tipChain = next.catch(() => {});
+    return next;
+  }
+
+  private async tipFetch(): Promise<string | null> {
+    for (let attempt = 1; ; attempt++) {
+      try {
+        await this.git(['fetch', '--quiet', 'origin', `+refs/heads/${this.branch}:refs/agentcomm/tip`]);
+        break;
+      } catch (err) {
+        const stderr = (err as { gitStderr?: string }).gitStderr ?? '';
+        if (/couldn'?t find remote ref|Could not find remote ref/i.test(stderr)) return null;
+        if (attempt < 4 && /cannot lock ref|unable to update local ref|File exists/i.test(stderr)) {
+          await sleep(20 * attempt + Math.floor(Math.random() * 40));
+          continue;
+        }
+        throw err;
+      }
     }
     return (await this.git(['rev-parse', 'refs/agentcomm/tip'])).toString('utf8').trim();
   }
@@ -195,6 +218,38 @@ export class GitBackend implements Backend, Claimable {
     } catch {
       throw notFound(key);
     }
+  }
+
+  /**
+   * One fetch, then every body read from local objects at that tip — the
+   * daemon's warm path. Key-by-key `get` would pay a fetch per key.
+   */
+  async snapshot(prefix: string): Promise<Map<string, Buffer>> {
+    const out = new Map<string, Buffer>();
+    const tip = await this.tip();
+    if (tip === null) return out;
+    const full = this.k(prefix);
+    const names = (await this.git(['ls-tree', '-r', '--name-only', '-z', tip]))
+      .toString('utf8')
+      .split('\0')
+      .filter((p) => p.length > 0 && p.startsWith(full) && p.startsWith(this.keyPrefix));
+    if (names.length === 0) return out;
+    const batch = await this.git(['cat-file', '--batch'], {
+      input: Buffer.from(names.map((p) => `${tip}:${p}`).join('\n') + '\n'),
+    });
+    // --batch emits "<oid> blob <size>\n<bytes>\n" per object, in input order
+    let off = 0;
+    for (const p of names) {
+      const nl = batch.indexOf(0x0a, off);
+      if (nl < 0) break;
+      const header = batch.subarray(off, nl).toString('utf8');
+      off = nl + 1;
+      if (header.endsWith(' missing')) continue; // vanished between ls-tree and read
+      const size = Number(header.split(' ')[2]);
+      out.set(p.slice(this.keyPrefix.length), Buffer.from(batch.subarray(off, off + size)));
+      off += size + 1; // body + trailing newline
+    }
+    return out;
   }
 
   async list(prefix: string): Promise<string[]> {

--- a/src/backends/socket.ts
+++ b/src/backends/socket.ts
@@ -61,6 +61,18 @@ class Rpc {
   }
 }
 
+/** Whether the daemon that wrote `<sockPath>.pid` is still running. */
+async function pidAlive(sockPath: string): Promise<boolean> {
+  try {
+    const pid = Number((await fs.readFile(sockPath + '.pid', 'utf8')).trim());
+    if (!Number.isInteger(pid) || pid <= 0) return false;
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 function ok(res: Record<string, unknown>): Record<string, unknown> {
   if (res.ok) return res;
   const err = new Error(String(res.error ?? 'daemon error'));
@@ -88,8 +100,13 @@ export class SocketBackend implements Backend {
       s.once('error', () => resolve(null));
     });
     if (!sock) {
-      await fs.rm(sockPath, { force: true }).catch(() => {}); // stale leftover
-      await fs.rm(sockPath + '.pid', { force: true }).catch(() => {});
+      // Unlink only a DEAD daemon's leftovers (issue #144): a connect error
+      // while the pid is alive is transient (busy accept queue) — unlinking
+      // then orphans a live daemon and triggers a respawn stampede.
+      if (!(await pidAlive(sockPath))) {
+        await fs.rm(sockPath, { force: true }).catch(() => {}); // stale leftover
+        await fs.rm(sockPath + '.pid', { force: true }).catch(() => {});
+      }
       return null;
     }
     const rpc = new Rpc(sock);
@@ -126,9 +143,9 @@ export class SocketBackend implements Backend {
     } catch {
       return null;
     }
-    // a git-backed daemon warms its mirror (a full fetch) before listening,
-    // and on loaded machines (CI) even node startup can crawl — the window
-    // is tunable so tests on starved runners can wait longer
+    // the daemon binds its socket before warming the mirror, so this window
+    // only covers node startup + backend open — but on loaded machines (CI)
+    // even that can crawl, so tests on starved runners can wait longer
     const waitMs = Math.max(1_000, Number(process.env.AGENTCOMM_DAEMON_SPAWN_WAIT_MS ?? 10_000));
     for (let waited = 0; waited < waitMs; waited += 100) {
       await new Promise((r) => setTimeout(r, 100));

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -7,6 +7,12 @@
  * read-your-write always holds. `claim` is forwarded verbatim — atomicity
  * must come from the store, never from a cache.
  *
+ * The socket binds BEFORE the first poll (issue #144): warming a large bus
+ * key-by-key can take minutes on round-trip-per-read stores, and a daemon
+ * that is invisible until then makes every client spawn another daemon — a
+ * stampede that never converges. Clients connect immediately; data ops just
+ * block until the warm-up finishes.
+ *
  * The protocol is newline-delimited JSON, the Backend interface verbatim:
  *   → {id, op: 'get'|'put'|'list'|'delete'|'exists'|'move'|'claim'|'info'|'stop', ...}
  *   ← {id, ok: true, ...} | {id, ok: false, error, code?}
@@ -18,7 +24,7 @@ import * as path from 'node:path';
 import { promises as fs } from 'node:fs';
 import { createHash } from 'node:crypto';
 import { createBackend } from './backends/index.js';
-import { isClaimable, type Backend } from './types.js';
+import { isClaimable, isSnapshottable, type Backend } from './types.js';
 
 export function daemonDir(): string {
   return process.env.AGENTCOMM_DAEMON_DIR ?? path.join(os.homedir(), '.cache', 'agentcomm', 'd');
@@ -49,55 +55,6 @@ export async function runDaemon(uri: string): Promise<void> {
   const backend: Backend = await createBackend(uri);
   const claimable = isClaimable(backend);
 
-  // warm mirror: full key set + bodies. Message blobs are immutable; agent
-  // records mutate (heartbeats), so those are refreshed on every poll.
-  const mirror = new Map<string, Buffer>();
-  let keys = new Set<string>();
-
-  async function poll(): Promise<void> {
-    // Snapshot the outbox BEFORE listing the store: a key is always in at
-    // least one of the two (spool until delivered, store afterwards) — the
-    // other order can miss it mid-flush for a full poll cycle. The snapshot
-    // runs under the flush mutex (issue #79): reading a spool file while the
-    // flusher rm's it silently dropped the key for a cycle under load.
-    const spooled: string[] = await snapshotSpool();
-    const listed = await backend.list('');
-    const next = new Set([...listed, ...spooled]);
-    for (const k of listed) {
-      if (!mirror.has(k) || k.startsWith('agents/')) {
-        try {
-          mirror.set(k, await backend.get(k));
-        } catch {
-          next.delete(k); // vanished between list and get
-        }
-      }
-    }
-    for (const k of mirror.keys()) if (!next.has(k)) mirror.delete(k);
-    keys = next;
-  }
-
-  async function snapshotSpool(): Promise<string[]> {
-    const take = async (): Promise<string[]> => {
-      const keys: string[] = [];
-      try {
-        for (const f of (await fs.readdir(sockPath + '.spool')).filter((x) => !x.startsWith('.'))) {
-          try {
-            const { key } = JSON.parse(
-              await fs.readFile(path.join(sockPath + '.spool', f), 'utf8'),
-            ) as { key: string };
-            keys.push(key);
-          } catch { /* entry mid-write */ }
-        }
-      } catch { /* spool not created yet */ }
-      return keys;
-    };
-    // before the socket dir exists (first poll) there is no spool nor mutex state
-    return typeof withSpoolRef === 'function' ? withSpoolRef(take) : take();
-  }
-  let withSpoolRef: (<T>(fn: () => Promise<T>) => Promise<T>) | null = null;
-
-  await poll();
-
   let lastActivity = Date.now();
   const sockPath = socketPathFor(uri);
   await fs.mkdir(path.dirname(sockPath), { recursive: true });
@@ -105,32 +62,177 @@ export async function runDaemon(uri: string): Promise<void> {
   // Two instances may autostart simultaneously for the same bus. Never
   // steal a LIVE peer's socket — if someone already answers, bow out and
   // let every client share that one daemon. Only a dead socket is removed.
-  const peerAlive = await new Promise<boolean>((resolve) => {
-    const probe = net.createConnection(sockPath);
-    const timer = setTimeout(() => {
-      probe.destroy();
-      resolve(false);
-    }, 1000);
-    probe.once('connect', () => {
-      clearTimeout(timer);
-      probe.destroy();
-      resolve(true);
+  const probePeer = (): Promise<boolean> =>
+    new Promise<boolean>((resolve) => {
+      const probe = net.createConnection(sockPath);
+      const timer = setTimeout(() => {
+        probe.destroy();
+        resolve(false);
+      }, 1000);
+      probe.once('connect', () => {
+        clearTimeout(timer);
+        probe.destroy();
+        resolve(true);
+      });
+      probe.once('error', () => {
+        clearTimeout(timer);
+        resolve(false);
+      });
     });
-    probe.once('error', () => {
-      clearTimeout(timer);
-      resolve(false);
-    });
-  });
-  if (peerAlive) {
-    process.stderr.write(`agentcomm daemon: another daemon already serves ${uri} — exiting
-`);
+  const bowOut = async (): Promise<never> => {
+    process.stderr.write(`agentcomm daemon: another daemon already serves ${uri} — exiting\n`);
     await backend.close?.().catch(() => {});
     process.exit(0);
+  };
+  if (await probePeer()) await bowOut();
+
+  // Outbox spool: puts are accepted onto disk and delivered by the flusher,
+  // so `send` acks in milliseconds while delivery (a git push, an API call)
+  // happens on the daemon's clock — FIFO, retried, surviving restarts.
+  const spoolDir = sockPath + '.spool';
+  await fs.mkdir(spoolDir, { recursive: true });
+  let spoolSeq = 0;
+  let flushFailures = 0;
+  async function spoolAdd(key: string, data: Buffer): Promise<void> {
+    const name = `${String(Date.now()).padStart(14, '0')}-${String(++spoolSeq).padStart(6, '0')}`;
+    const tmp = path.join(spoolDir, '.' + name);
+    await fs.writeFile(tmp, JSON.stringify({ key, data: data.toString('base64') }));
+    await fs.rename(tmp, path.join(spoolDir, name)); // atomic appearance
   }
-  await fs.rm(sockPath, { force: true });
+  async function spoolDepth(): Promise<number> {
+    try {
+      return (await fs.readdir(spoolDir)).filter((f) => !f.startsWith('.')).length;
+    } catch {
+      return 0;
+    }
+  }
+  // One mutex serializes the flusher against spool mutations (a move/delete
+  // of a not-yet-delivered key rewrites its spool entry — racing the flusher
+  // there would deliver the stale key and lose the rewrite).
+  let spoolChain: Promise<unknown> = Promise.resolve();
+  function withSpool<T>(fn: () => Promise<T>): Promise<T> {
+    const next = spoolChain.then(fn, fn);
+    spoolChain = next.catch(() => {});
+    return next;
+  }
+  function flush(): Promise<void> {
+    return withSpool(async () => {
+      const entries = (await fs.readdir(spoolDir)).filter((f) => !f.startsWith('.')).sort();
+      for (const f of entries) {
+        const file = path.join(spoolDir, f);
+        try {
+          const { key, data } = JSON.parse(await fs.readFile(file, 'utf8')) as { key: string; data: string };
+          await backend.put(key, Buffer.from(data, 'base64'));
+          await fs.rm(file, { force: true });
+          flushFailures = 0;
+        } catch {
+          flushFailures++;
+          break; // keep FIFO order — retry this entry next tick
+        }
+      }
+    });
+  }
+  /** If `key` is still spooled, rewrite/remove it locally and return true. */
+  function spoolTake(key: string, rewriteTo?: string): Promise<boolean> {
+    return withSpool(async () => {
+      for (const f of (await fs.readdir(spoolDir)).filter((x) => !x.startsWith('.')).sort()) {
+        const file = path.join(spoolDir, f);
+        try {
+          const entry = JSON.parse(await fs.readFile(file, 'utf8')) as { key: string; data: string };
+          if (entry.key !== key) continue;
+          if (rewriteTo) await fs.writeFile(file, JSON.stringify({ ...entry, key: rewriteTo }));
+          else await fs.rm(file, { force: true });
+          return true;
+        } catch { /* unreadable entry: leave for the flusher */ }
+      }
+      return false;
+    });
+  }
+
+  // warm mirror: full key set + bodies. On Snapshottable backends every poll
+  // is one round trip (bodies included); elsewhere the poll carries keys only
+  // and bodies fill lazily through the `get` passthrough — message blobs are
+  // immutable, and agent records (which mutate: heartbeats) are invalidated
+  // each poll so the next read refetches them.
+  const mirror = new Map<string, Buffer>();
+  let keys = new Set<string>();
+
+  /** Snapshot the outbox BEFORE listing the store: a key is always in at
+   * least one of the two (spool until delivered, store afterwards) — the
+   * other order can miss it mid-flush for a full poll cycle. Runs under the
+   * flush mutex (issue #79): reading a spool file while the flusher rm's it
+   * silently dropped the key for a cycle under load. */
+  function snapshotSpool(): Promise<string[]> {
+    return withSpool(async () => {
+      const spooled: string[] = [];
+      try {
+        for (const f of (await fs.readdir(spoolDir)).filter((x) => !x.startsWith('.'))) {
+          try {
+            const { key } = JSON.parse(await fs.readFile(path.join(spoolDir, f), 'utf8')) as {
+              key: string;
+            };
+            spooled.push(key);
+          } catch { /* entry mid-write */ }
+        }
+      } catch { /* spool gone (shutdown) */ }
+      return spooled;
+    });
+  }
+
+  async function doPoll(): Promise<void> {
+    const spooled = await snapshotSpool();
+    if (isSnapshottable(backend)) {
+      const snap = await backend.snapshot('');
+      for (const k of spooled) {
+        const body = snap.get(k) ?? mirror.get(k);
+        if (body) snap.set(k, body); // spooled but not delivered yet — keep the local body
+      }
+      mirror.clear();
+      for (const [k, v] of snap) mirror.set(k, v);
+      keys = new Set([...snap.keys(), ...spooled]);
+      return;
+    }
+    const listed = await backend.list('');
+    const next = new Set([...listed, ...spooled]);
+    for (const k of mirror.keys()) {
+      if (!next.has(k) || k.startsWith('agents/')) mirror.delete(k);
+    }
+    keys = next;
+  }
+  // Coalesce: timer ticks, `refresh`, and post-claim polls that overlap a
+  // slow poll join it instead of stacking concurrent fetches.
+  let inFlight: Promise<void> | null = null;
+  function poll(): Promise<void> {
+    inFlight ??= doPoll().finally(() => {
+      inFlight = null;
+    });
+    return inFlight;
+  }
+
+  // First poll starts now and runs behind the (soon-bound) socket; if it
+  // fails the daemon is useless — clean up and die so clients fall back to
+  // direct connections.
+  let warmed = false;
+  let bound = false;
+  const ready: Promise<void> = poll();
+  ready.then(
+    () => {
+      warmed = true;
+    },
+    (err: Error) => {
+      process.stderr.write(`agentcomm daemon: warm-up failed for ${uri}: ${err.message}\n`);
+      if (bound) {
+        void fs.rm(sockPath, { force: true }).catch(() => {});
+        void fs.rm(sockPath + '.pid', { force: true }).catch(() => {});
+      }
+      void backend.close?.().catch(() => {});
+      setTimeout(() => process.exit(1), 100);
+    },
+  );
 
   async function handle(req: Req): Promise<Record<string, unknown>> {
     lastActivity = Date.now();
+    if (req.op !== 'info' && req.op !== 'stop') await ready; // data ops wait out the warm-up
     switch (req.op) {
       case 'info':
         return {
@@ -139,6 +241,7 @@ export async function runDaemon(uri: string): Promise<void> {
           claimable,
           pollMs,
           pid: process.pid,
+          warming: !warmed,
           outbox: await spoolDepth(),
           flushFailures,
         };
@@ -228,75 +331,29 @@ export async function runDaemon(uri: string): Promise<void> {
     sock.on('error', () => {});
   });
 
-  await new Promise<void>((resolve, reject) => {
-    server.once('error', reject);
-    server.listen(sockPath, resolve);
-  });
+  // Bind now — warm later. On EADDRINUSE the path is either a live peer that
+  // bound between our probe and our listen (bow out) or a dead leftover
+  // (remove and retry). Never rm first: that stole a live peer's socket.
+  const listen = (): Promise<void> =>
+    new Promise((resolve, reject) => {
+      const onErr = (err: Error): void => reject(err);
+      server.once('error', onErr);
+      server.listen(sockPath, () => {
+        server.removeListener('error', onErr);
+        resolve();
+      });
+    });
+  try {
+    await listen();
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== 'EADDRINUSE') throw err;
+    if (await probePeer()) await bowOut();
+    await fs.rm(sockPath, { force: true });
+    await listen();
+  }
+  bound = true;
   await fs.writeFile(sockPath + '.pid', String(process.pid));
 
-  // Outbox spool: puts are accepted onto disk and delivered by the flusher,
-  // so `send` acks in milliseconds while delivery (a git push, an API call)
-  // happens on the daemon's clock — FIFO, retried, surviving restarts.
-  const spoolDir = sockPath + '.spool';
-  await fs.mkdir(spoolDir, { recursive: true });
-  let spoolSeq = 0;
-  let flushFailures = 0;
-  async function spoolAdd(key: string, data: Buffer): Promise<void> {
-    const name = `${String(Date.now()).padStart(14, '0')}-${String(++spoolSeq).padStart(6, '0')}`;
-    const tmp = path.join(spoolDir, '.' + name);
-    await fs.writeFile(tmp, JSON.stringify({ key, data: data.toString('base64') }));
-    await fs.rename(tmp, path.join(spoolDir, name)); // atomic appearance
-  }
-  async function spoolDepth(): Promise<number> {
-    try {
-      return (await fs.readdir(spoolDir)).filter((f) => !f.startsWith('.')).length;
-    } catch {
-      return 0;
-    }
-  }
-  // One mutex serializes the flusher against spool mutations (a move/delete
-  // of a not-yet-delivered key rewrites its spool entry — racing the flusher
-  // there would deliver the stale key and lose the rewrite).
-  let spoolChain: Promise<unknown> = Promise.resolve();
-  function withSpool<T>(fn: () => Promise<T>): Promise<T> {
-    const next = spoolChain.then(fn, fn);
-    spoolChain = next.catch(() => {});
-    return next;
-  }
-  withSpoolRef = withSpool;
-  function flush(): Promise<void> {
-    return withSpool(async () => {
-      const entries = (await fs.readdir(spoolDir)).filter((f) => !f.startsWith('.')).sort();
-      for (const f of entries) {
-        const file = path.join(spoolDir, f);
-        try {
-          const { key, data } = JSON.parse(await fs.readFile(file, 'utf8')) as { key: string; data: string };
-          await backend.put(key, Buffer.from(data, 'base64'));
-          await fs.rm(file, { force: true });
-          flushFailures = 0;
-        } catch {
-          flushFailures++;
-          break; // keep FIFO order — retry this entry next tick
-        }
-      }
-    });
-  }
-  /** If `key` is still spooled, rewrite/remove it locally and return true. */
-  function spoolTake(key: string, rewriteTo?: string): Promise<boolean> {
-    return withSpool(async () => {
-      for (const f of (await fs.readdir(spoolDir)).filter((x) => !x.startsWith('.')).sort()) {
-        const file = path.join(spoolDir, f);
-        try {
-          const entry = JSON.parse(await fs.readFile(file, 'utf8')) as { key: string; data: string };
-          if (entry.key !== key) continue;
-          if (rewriteTo) await fs.writeFile(file, JSON.stringify({ ...entry, key: rewriteTo }));
-          else await fs.rm(file, { force: true });
-          return true;
-        } catch { /* unreadable entry: leave for the flusher */ }
-      }
-      return false;
-    });
-  }
   const flushMs = Math.max(100, Number(process.env.AGENTCOMM_FLUSH_MS ?? 250));
   const flushTimer = setInterval(() => void flush(), flushMs);
   flushTimer.unref?.();
@@ -312,6 +369,7 @@ export async function runDaemon(uri: string): Promise<void> {
   const housekeepMs = Math.max(10_000, Number(process.env.AGENTCOMM_HOUSEKEEP_MS ?? 6 * 3600_000));
   const archiveTtl = Number(process.env.AGENTCOMM_PURGE_AFTER_MS ?? 30 * 24 * 3600_000);
   async function housekeep(): Promise<void> {
+    await ready; // never stack backend calls onto an unfinished warm-up
     const now = Date.now();
     if (archiveTtl > 0) {
       for (const k of await backend.list('read/')) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -66,6 +66,17 @@ export interface Claimable {
   claim(queue: string, owner: string): Promise<Message | null>;
 }
 
+/**
+ * Optional capability: read every key (and body) under a prefix in one
+ * atomic pass. On stores where each `get` pays a network round trip (a git
+ * fetch, a REST call), warming a large bus key-by-key is minutes of wall
+ * clock — the bus daemon uses this to warm its mirror in one round trip.
+ */
+export interface Snapshottable {
+  /** All keys under `prefix` with their bodies, read at a single consistent point. */
+  snapshot(prefix: string): Promise<Map<string, Buffer>>;
+}
+
 /** Optional capability: block until a message arrives (push instead of poll). */
 export interface Waitable {
   /**
@@ -81,6 +92,10 @@ export function isClaimable(b: Backend): b is Backend & Claimable {
 
 export function isWaitable(b: Backend): b is Backend & Waitable {
   return typeof (b as Partial<Waitable>).waitPush === 'function';
+}
+
+export function isSnapshottable(b: Backend): b is Backend & Snapshottable {
+  return typeof (b as Partial<Snapshottable>).snapshot === 'function';
 }
 
 /** Thrown when an optional driver (better-sqlite3, pg, aws/gcs sdk) is missing. */

--- a/test/daemon.e2e.test.ts
+++ b/test/daemon.e2e.test.ts
@@ -164,6 +164,35 @@ describe('bus daemon: same semantics, immediate answers', () => {
     expect(after.pid).toBe(before.pid); // the incumbent survived untouched
   });
 
+  it('git-backed daemon: one-round-trip snapshot warm serves pre-existing keys (issue #144)', async () => {
+    const dir = await mkTmp();
+    const remote = path.join(dir, 'remote.git');
+    execFileSync('git', ['init', '--bare', '--quiet', remote]);
+    const extra = {
+      AGENTCOMM_BACKEND: `git+file://${remote}`,
+      AGENTCOMM_GIT_CACHE_DIR: path.join(dir, 'gitcache'),
+    };
+
+    // seed the bus before any daemon exists — warm-up must mirror it
+    const seed = await run(['send', 'alpha', 'pre-daemon message', '--as', 'seeder', '--direct'], dir, extra);
+    expect(seed.code, seed.stderr).toBe(0);
+
+    const reg = await run(['register', '--as', 'alpha', '--daemon'], dir, extra);
+    expect(reg.code, reg.stderr).toBe(0);
+
+    const status = await run(['daemon', 'status', '--json'], dir, extra);
+    expect(status.code, status.stderr).toBe(0);
+    const info = JSON.parse(status.stdout) as { running: boolean; claimable: boolean; warming: boolean };
+    expect(info.running).toBe(true);
+    expect(info.claimable).toBe(true); // git backend supports claim, through the daemon too
+    expect(info.warming).toBe(false); // the register above already waited out the warm
+
+    const inbox = await run(['inbox', '--as', 'alpha', '--daemon', '--json'], dir, extra);
+    expect(inbox.code, inbox.stderr).toBe(0);
+    const msgs = JSON.parse(inbox.stdout) as Array<{ body: string }>;
+    expect(msgs.map((m) => m.body)).toContain('pre-daemon message');
+  }, 120000);
+
   it('daemon housekeeping trims the archive but NEVER registrations (issue #100)', async () => {
     const dir = await mkTmp();
     await run(['register', '--as', 'fresh-agent', '--daemon'], dir);

--- a/test/git.e2e.test.ts
+++ b/test/git.e2e.test.ts
@@ -73,6 +73,23 @@ describe('GitBackend (local bare remotes — same code path as any host)', () =>
     await expect(b.delete('inbox/a/001.json')).resolves.toBeUndefined();
   }, 60000);
 
+  it('snapshot: one pass returns every key + body, honors prefixes (issue #144)', async () => {
+    const { uri, cache } = await bareRemote();
+    const b = await open(uri, cache);
+
+    expect((await b.snapshot('')).size).toBe(0); // branch not born yet
+
+    await b.put('inbox/a/001.json', Buffer.from('one'));
+    await b.put('inbox/b/001.json', Buffer.from('two'));
+    await b.put('agents/a.json', Buffer.from('{"alias":"a"}'));
+
+    const all = await b.snapshot('');
+    expect([...all.keys()].sort()).toEqual(['agents/a.json', 'inbox/a/001.json', 'inbox/b/001.json']);
+    for (const [k, v] of all) expect(v.equals(await b.get(k))).toBe(true); // bodies match per-key reads
+
+    expect([...(await b.snapshot('inbox/a/')).keys()]).toEqual(['inbox/a/001.json']);
+  }, 60000);
+
   it('move is ATOMIC — one commit relocates the key', async () => {
     const { uri, cache } = await bareRemote();
     const b = await open(uri, cache);


### PR DESCRIPTION
Closes #144.

## What was broken

On a large bus (~1,000 keys) the daemon system collapsed entirely — see #144 for the full diagnosis. The short version: `GitBackend.get()` pays a network fetch per read, the daemon warmed its mirror key-by-key **before** binding its socket (~40 minutes of invisibility), clients gave up after 10s and stampede-spawned more daemons, and the github:// variant burned ~1 REST call per key per spawn until the hourly quota hit zero. Every harness hook then took the direct-connection path and blew its timeout.

## The fix

1. **`Snapshottable` capability** (`types.ts`): optional `snapshot(prefix)` returning all keys+bodies in one pass. `GitBackend` implements it as one fetch + `ls-tree -r` + `cat-file --batch` — warm-up drops from ~40 min to seconds.
2. **Bind before warm** (`daemon.ts`): probe → listen → write pid, *then* start the first poll; data ops await a `ready` promise. `listen` retries on `EADDRINUSE` (bowing out to a live peer) instead of pre-emptively `rm`-ing the socket path, which could steal a peer's freshly bound socket. Polls are coalesced so a slow warm never stacks concurrent fetches.
3. **Lazy bodies on non-snapshot backends**: a poll is now one `list`; bodies fill through the existing get-passthrough (message blobs are immutable), and mutable `agents/` records are invalidated per poll instead of refetched. The github:// warm becomes one list call instead of ~1,000 GETs.
4. **Clients never orphan a live daemon** (`socket.ts`): the socket/pid files are only unlinked when the pid-file process is actually dead.
5. **Serialized, retried `tip()`** (`git.ts`): the daemon drives poll, outbox flusher, and client ops through one `GitBackend` concurrently; concurrent fetches force-updating `refs/agentcomm/tip` collided on its ref lock and made ops throw spuriously — `Bus.inbox` swallowed the failed move as "another consumer claimed it first" and silently returned `[]` while the message stayed in the inbox. In-instance fetches now queue; cross-process collisions retry with backoff.

## Testing

- New: `GitBackend.snapshot` unit coverage (bodies match per-key reads, prefix filtering, unborn branch).
- New: git-backed daemon e2e — seeds a bus, then verifies the daemon's one-round-trip warm serves the pre-existing key through register/status/inbox (this test reliably reproduced the empty-inbox race before fix 5; 5/5 stable after).
- All 11 existing daemon e2e tests and the full git e2e suite pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)