### PR TITLE
release prep: 0.19.1 [0.19.1]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yonidavidson/agentcomm",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@yonidavidson/agentcomm",
-      "version": "0.19.0",
+      "version": "0.19.1",
       "license": "MIT",
       "bin": {
         "agentcomm": "dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yonidavidson/agentcomm",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "description": "A tiny mailbox/message bus for AI agents that shell out to one CLI. Pluggable storage backends behind a single Backend interface.",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
Version bump for 0.19.1 — ships the daemon warm-up stampede fix (#144, merged in #145) to the npm registry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)