### PR TITLE
telemetry precision: exact merge parsing, worktree-aware agent refs, event dedup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yonidavidson/agentcomm",
-  "version": "0.19.1",
+  "version": "0.19.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@yonidavidson/agentcomm",
-      "version": "0.19.1",
+      "version": "0.19.2",
       "license": "MIT",
       "bin": {
         "agentcomm": "dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yonidavidson/agentcomm",
-  "version": "0.19.1",
+  "version": "0.19.2",
   "description": "A tiny mailbox/message bus for AI agents that shell out to one CLI. Pluggable storage backends behind a single Backend interface.",
   "type": "module",
   "license": "MIT",

--- a/src/hook-run.ts
+++ b/src/hook-run.ts
@@ -26,7 +26,9 @@ interface HookInput {
   stop_hook_active?: boolean;
   task_subject?: string;
   tool_name?: string;
-  tool_input?: { skill?: string; name?: string; subagent_type?: string; command?: string };
+  tool_use_id?: string;
+  tool_input?: { skill?: string; name?: string; subagent_type?: string; command?: string; prompt?: string };
+  tool_response?: unknown;
 }
 
 async function readStdinJson(): Promise<HookInput> {
@@ -243,6 +245,9 @@ async function hookSessionStart(input: HookInput): Promise<void> {
             `\`agentcomm emit --type ${r.on}-outcome${name} --ref "$(git branch --show-current)" --attrs '{"…":"…"}'\``,
         );
       }
+      lines.push(
+        '  (Some repos emit these outcomes automatically from their own scripts — if a script already reported it, do not emit a duplicate.)',
+      );
     }
   } catch {
     /* fail open — telemetry must never block a session */
@@ -485,6 +490,130 @@ async function hookTaskStatus(input: HookInput): Promise<void> {
 
 // ── telemetry ───────────────────────────────────────────────────────────────
 
+/** What a parsed merge invocation tells us — enough to correlate the event. */
+export type MergeInfo = { kind: 'git-merge'; source?: string } | { kind: 'gh-pr-merge'; pr?: string };
+
+const GIT_MERGE_RE = /(?:^|[\s;&|(])git\s+merge(?=\s|$)/;
+const GH_PR_MERGE_RE = /(?:^|[\s;&|(])gh\s+pr\s+merge(?=\s|$)/;
+/** Chars that end the merge invocation inside a compound command line. */
+const COMMAND_END = /[;|&\n]/;
+
+/**
+ * Parse a Bash command for a REAL merge invocation, or null when it isn't
+ * one. `(?=\s|$)` (not `\b`) keeps plumbing like `git merge-base`,
+ * `merge-tree` and `merge-file` out — a hyphen is a word boundary, so `\b`
+ * matched them all. `git merge --abort|--quit` is unwinding a merge, not
+ * performing one, so it is null too.
+ */
+export function parseMergeCommand(command: string): MergeInfo | null {
+  const gh = GH_PR_MERGE_RE.exec(command);
+  if (gh) {
+    const rest = command.slice(gh.index + gh[0].length);
+    const tail = rest.split(COMMAND_END, 1)[0] ?? '';
+    for (const tok of tail.trim().split(/\s+/)) {
+      const m = /^#?(\d+)$/.exec(tok) ?? /\/pull\/(\d+)/.exec(tok);
+      // A bare number could also be a numeric flag value; for telemetry the
+      // first numeric token being the PR is the overwhelmingly common case.
+      if (m) return { kind: 'gh-pr-merge', pr: m[1] };
+    }
+    return { kind: 'gh-pr-merge' };
+  }
+  const git = GIT_MERGE_RE.exec(command);
+  if (git) {
+    const rest = command.slice(git.index + git[0].length);
+    // collapse quoted spans to one opaque token so "-m \"two words\"" skips cleanly
+    const tail = (rest.split(COMMAND_END, 1)[0] ?? '').replace(/"[^"]*"|'[^']*'/g, '__quoted__');
+    const tokens = tail.trim().split(/\s+/).filter(Boolean);
+    const flags: string[] = [];
+    let source: string | undefined;
+    for (let i = 0; i < tokens.length; i++) {
+      const tok = tokens[i]!;
+      if (tok === '-m' || tok === '-F' || tok === '--message' || tok === '--file') {
+        i++; // skip the flag's value
+      } else if (tok.startsWith('-')) {
+        flags.push(tok);
+      } else if (!source) {
+        source = tok;
+      }
+    }
+    if (flags.includes('--abort') || flags.includes('--quit')) return null;
+    return { kind: 'git-merge', ...(source ? { source } : {}) };
+  }
+  return null;
+}
+
+/** True only when the harness payload clearly marks the tool call as failed; unknown shapes → false. */
+function toolFailed(resp: unknown): boolean {
+  if (typeof resp !== 'object' || resp === null) return false;
+  const r = resp as Record<string, unknown>;
+  return r.is_error === true || r.success === false;
+}
+
+/** Absolute filesystem paths mentioned in free text — deduped, deepest-first, capped. */
+export function extractAbsolutePaths(text: string, cap = 8): string[] {
+  const seen = new Set<string>();
+  // anchor to a boundary so `src/foo.ts` doesn't leak a phantom `/foo.ts`
+  for (const m of text.matchAll(/(^|[\s"'`(\[<])(\/[^\s"'`)(\[\]<>,;]+)/g)) {
+    const p = (m[2] ?? '').replace(/[.,:;)\]}"']+$/, '');
+    if (p.length > 1) seen.add(p);
+  }
+  return [...seen].sort((a, b) => b.split('/').length - a.split('/').length).slice(0, cap);
+}
+
+/** Branch of the git checkout containing `p` (falling back to its dirname), or null. */
+async function branchForPath(p: string): Promise<string | null> {
+  let dir = p;
+  try {
+    if (!(await fs.stat(p)).isDirectory()) dir = path.dirname(p);
+  } catch {
+    dir = path.dirname(p);
+    try {
+      await fs.stat(dir);
+    } catch {
+      return null;
+    }
+  }
+  return new Promise((resolve) =>
+    execFile('git', ['-C', dir, 'branch', '--show-current'], { timeout: 1_500 }, (err, out) =>
+      resolve(err ? null : out.trim() || null),
+    ),
+  );
+}
+
+const DEFAULT_BRANCHES = new Set(['main', 'master']);
+
+/**
+ * Best ref for an agent-ran event. The event fires in the SESSION that
+ * spawned the subagent, whose cwd is often the primary checkout while the
+ * actual work lives in a sibling git worktree — so the cwd branch says
+ * "main" even though the run was about a feature branch. The subagent
+ * prompt usually names paths inside that worktree; the deepest path that
+ * resolves to a non-default branch is the honest ref. Falls back to the
+ * cwd branch, with provenance so readers can discount cwd-derived refs.
+ */
+async function resolveAgentRef(
+  prompt: string | undefined,
+  cwd: string,
+): Promise<{ ref: string | null; source: 'prompt-path' | 'cwd' }> {
+  let fromPath: string | null = null;
+  let gitCalls = 0;
+  for (const p of extractAbsolutePaths(prompt ?? '')) {
+    if (gitCalls >= 5) break;
+    gitCalls++;
+    const branch = await branchForPath(p);
+    if (!branch) continue;
+    if (!DEFAULT_BRANCHES.has(branch)) return { ref: branch, source: 'prompt-path' };
+    fromPath ??= branch; // deepest default-named branch — still evidence-based
+  }
+  if (fromPath) return { ref: fromPath, source: 'prompt-path' };
+  const ref = await new Promise<string | null>((resolve) =>
+    execFile('git', ['-C', cwd, 'branch', '--show-current'], { timeout: 1_500 }, (err, out) =>
+      resolve(err ? null : out.trim() || null),
+    ),
+  );
+  return { ref, source: 'cwd' };
+}
+
 async function hookTelemetry(input: HookInput): Promise<void> {
   const cwd = input.cwd || process.cwd();
   if (!(await onTheBus(cwd))) return;
@@ -527,10 +656,14 @@ async function hookTelemetry(input: HookInput): Promise<void> {
     }
     if (hook === 'PostToolUse' && input.tool_name === 'Bash') {
       const command = String(input.tool_input?.command ?? '');
-      if (/(^|[\s;&|(])git\s+merge\b/.test(command) || /(^|[\s;&|(])gh\s+pr\s+merge\b/.test(command)) {
-        if (tracked('merge')) {
-          return { type: 'merged', attrs: { command: command.length > 120 ? command.slice(0, 119) + '…' : command } };
-        }
+      const merge = parseMergeCommand(command);
+      if (merge && tracked('merge') && !toolFailed(input.tool_response)) {
+        const attrs: Record<string, unknown> = {
+          command: command.length > 120 ? command.slice(0, 119) + '…' : command,
+        };
+        if (merge.kind === 'git-merge' && merge.source) attrs.source = merge.source;
+        if (merge.kind === 'gh-pr-merge' && merge.pr) attrs.pr = merge.pr;
+        return { type: 'merged', attrs };
       }
       return null;
     }
@@ -550,9 +683,22 @@ async function hookTelemetry(input: HookInput): Promise<void> {
   const event = deriveEvent();
   if (!event) return;
 
-  const ref = await new Promise<string | null>((resolve) =>
-    execFile('git', ['-C', cwd, 'branch', '--show-current'], (err, out) => resolve(err ? null : out.trim() || null)),
-  );
+  // The harness's tool_use_id makes the event's identity exact: a re-derivation
+  // of the SAME tool call (the same hook registered in two settings scopes)
+  // shares it and dedups, while two genuinely distinct calls that happen to
+  // look alike — parallel spawns of one agent type — differ and both count.
+  if (input.tool_use_id) event.attrs = { ...event.attrs, tool_use: input.tool_use_id };
+
+  let ref: string | null;
+  if (event.type === 'agent-ran') {
+    const resolved = await resolveAgentRef(input.tool_input?.prompt, cwd);
+    ref = resolved.ref;
+    event.attrs = { ...event.attrs, ref_source: resolved.source };
+  } else {
+    ref = await new Promise<string | null>((resolve) =>
+      execFile('git', ['-C', cwd, 'branch', '--show-current'], (err, out) => resolve(err ? null : out.trim() || null)),
+    );
+  }
 
   await cli(
     [

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -162,10 +162,11 @@ async function drainSpoolFile(file: string): Promise<TelemetryEvent[]> {
  * but a transient backend error does not eat the batch.
  */
 export async function flushEvents(backend: Backend, busUri: string, respoolAgent: string): Promise<number> {
-  const events: TelemetryEvent[] = [];
+  let events: TelemetryEvent[] = [];
   for (const file of await spoolFiles(busUri)) events.push(...(await drainSpoolFile(file)));
   if (events.length === 0) return 0;
   events.sort((a, b) => (Date.parse(a.ts) || 0) - (Date.parse(b.ts) || 0) || a.id.localeCompare(b.id));
+  events = dedupeEvents(events);
   const batch: EventBatch = { v: 1, events };
   const id = randomUUID().replace(/-/g, '').slice(0, 12);
   try {
@@ -175,6 +176,52 @@ export async function flushEvents(backend: Backend, busUri: string, respoolAgent
     await spoolEvents(busUri, respoolAgent, events);
     throw err;
   }
+}
+
+// ── dedup ───────────────────────────────────────────────────────────────────
+// Harnesses can end up running the same hook more than once for a single
+// underlying occurrence (the same hook command registered in more than one
+// settings scope is the common case): each spawn derives the same event and
+// emits it independently, so the store accumulates twins that differ only in
+// their minted id/ts. Identity below is everything BUT id/ts; a repeat inside
+// the window is the same occurrence, a repeat beyond it is a genuine re-run.
+
+export const DEDUP_WINDOW_MS = 10_000;
+
+/** JSON.stringify with object keys sorted at every depth, so equal attrs stringify equally. */
+function stableJson(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(stableJson).join(',')}]`;
+  if (typeof value === 'object' && value !== null) {
+    const entries = Object.entries(value as Record<string, unknown>)
+      .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+      .map(([k, v]) => `${JSON.stringify(k)}:${stableJson(v)}`);
+    return `{${entries.join(',')}}`;
+  }
+  return JSON.stringify(value) ?? 'null';
+}
+
+/** Identity of an event minus its minted id/ts — re-derivations of one occurrence collide. */
+export function eventDedupKey(e: TelemetryEvent): string {
+  return stableJson([e.agent, e.session ?? null, e.type, e.name ?? null, e.ref ?? null, e.attrs ?? null]);
+}
+
+/**
+ * Collapse events whose identity already appeared within `windowMs` of the
+ * last KEPT twin. Input must be ts-sorted (both call sites sort first);
+ * keep-first, so a burst of N twins collapses to the earliest one.
+ */
+export function dedupeEvents(events: TelemetryEvent[], windowMs = DEDUP_WINDOW_MS): TelemetryEvent[] {
+  const lastKept = new Map<string, number>();
+  const out: TelemetryEvent[] = [];
+  for (const e of events) {
+    const key = eventDedupKey(e);
+    const ts = Date.parse(e.ts) || 0;
+    const prev = lastKept.get(key);
+    if (prev !== undefined && ts - prev < windowMs) continue;
+    lastKept.set(key, ts);
+    out.push(e);
+  }
+  return out;
 }
 
 let _counter = 0;
@@ -254,5 +301,9 @@ export async function listEvents(backend: Backend, filter: EventFilter = {}): Pr
     }
   }
   out.sort((a, b) => (Date.parse(a.ts) || 0) - (Date.parse(b.ts) || 0) || a.id.localeCompare(b.id));
-  return out;
+  // Read-time dedup is authoritative: it also collapses twins that landed in
+  // DIFFERENT batches (two hook spawns racing a flush), which write-time
+  // dedup inside one batch cannot see — and it heals stores written before
+  // dedup existed.
+  return dedupeEvents(out);
 }

--- a/test/telemetry-hooks.e2e.test.ts
+++ b/test/telemetry-hooks.e2e.test.ts
@@ -133,14 +133,15 @@ describe('telemetry capture hooks (issue #100)', () => {
     const dir = await trackedRepo();
     // the same subagent skill is unreachable via the Skill tool when it sets
     // disable-model-invocation — the Task/Agent spawn is the only signal
+    // distinct tool_use ids: two separate spawns, as the harness reports them
     await runHook(
       'telemetry-capture.mjs',
-      { cwd: dir, hook_event_name: 'PostToolUse', tool_name: 'Task', tool_input: { subagent_type: 'code-review-nuclear' } },
+      { cwd: dir, hook_event_name: 'PostToolUse', tool_name: 'Task', tool_use_id: 't-1', tool_input: { subagent_type: 'code-review-nuclear' } },
       dir,
     );
     await runHook(
       'telemetry-capture.mjs',
-      { cwd: dir, hook_event_name: 'PostToolUse', tool_name: 'Agent', tool_input: { subagent_type: 'code-review-nuclear' } },
+      { cwd: dir, hook_event_name: 'PostToolUse', tool_name: 'Agent', tool_use_id: 't-2', tool_input: { subagent_type: 'code-review-nuclear' } },
       dir,
     );
     await runHook(
@@ -156,7 +157,47 @@ describe('telemetry capture hooks (issue #100)', () => {
     cliJson(['register', '--as', 'rider'], dir);
     const events = cliJson<Ev[]>(['events'], dir);
     expect(events).toHaveLength(2); // both tool spellings fire; untracked/typeless do not
-    for (const e of events) expect(e).toMatchObject({ type: 'agent-ran', name: 'code-review-nuclear', ref: 'feat-x' });
+    for (const e of events)
+      expect(e).toMatchObject({
+        type: 'agent-ran',
+        name: 'code-review-nuclear',
+        ref: 'feat-x',
+        attrs: { ref_source: 'cwd' },
+      });
+  });
+
+  it('agent-ran resolves its ref from a worktree path in the prompt, not the session cwd', async () => {
+    const dir = await trackedRepo(); // session cwd: a checkout on feat-x
+    const wt = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), 'agentcomm-telwt-')));
+    tmpRoots.push(wt);
+    execFileSync('git', ['-C', wt, 'init', '-q']);
+    execFileSync('git', ['-C', wt, 'symbolic-ref', 'HEAD', 'refs/heads/review-branch-1']);
+    await fs.mkdir(path.join(wt, 'src'), { recursive: true });
+    await fs.writeFile(path.join(wt, 'src', 'foo.ts'), 'export {};\n');
+
+    await runHook(
+      'telemetry-capture.mjs',
+      {
+        cwd: dir,
+        hook_event_name: 'PostToolUse',
+        tool_name: 'Task',
+        tool_use_id: 't-wt',
+        tool_input: {
+          subagent_type: 'code-review-nuclear',
+          prompt: `Review the changes in ${wt}/src/foo.ts and report findings.`,
+        },
+      },
+      dir,
+    );
+    cliJson(['register', '--as', 'rider'], dir);
+    const events = cliJson<Ev[]>(['events'], dir);
+    expect(events).toHaveLength(1);
+    // reverting the worktree-aware resolution turns this red: cwd gives feat-x
+    expect(events[0]).toMatchObject({
+      type: 'agent-ran',
+      ref: 'review-branch-1',
+      attrs: { ref_source: 'prompt-path' },
+    });
   });
 
   it('a merge command through Bash is recorded when tracked', async () => {
@@ -177,6 +218,105 @@ describe('telemetry capture hooks (issue #100)', () => {
     expect(events).toHaveLength(1);
     expect(events[0]).toMatchObject({ type: 'merged', ref: 'feat-x' });
     expect(String(events[0]!.attrs?.command)).toContain('git merge feat-x');
+  });
+
+  it('git plumbing and merge-unwinding commands are NOT recorded as merges', async () => {
+    const dir = await trackedRepo();
+    for (const command of [
+      'git merge-base --fork-point origin/main HEAD',
+      'git merge-tree A B',
+      'git merge-file ours base theirs',
+      'git merge --abort',
+      'gh pr view 123 --json state,mergeCommit,mergedAt',
+    ]) {
+      await runHook(
+        'telemetry-capture.mjs',
+        { cwd: dir, hook_event_name: 'PostToolUse', tool_name: 'Bash', tool_input: { command } },
+        dir,
+      );
+    }
+    cliJson(['register', '--as', 'rider'], dir);
+    expect(cliJson<Ev[]>(['events'], dir)).toEqual([]);
+  });
+
+  it('merged events carry the source branch or PR number, and a clearly-failed call is skipped', async () => {
+    const dir = await trackedRepo();
+    await runHook(
+      'telemetry-capture.mjs',
+      {
+        cwd: dir,
+        hook_event_name: 'PostToolUse',
+        tool_name: 'Bash',
+        tool_use_id: 't-m1',
+        tool_input: { command: 'git merge --no-ff -m "landing" feat-y' },
+        tool_response: { stdout: 'Merge made by the ort strategy.' }, // unknown-good shape → emits
+      },
+      dir,
+    );
+    await runHook(
+      'telemetry-capture.mjs',
+      {
+        cwd: dir,
+        hook_event_name: 'PostToolUse',
+        tool_name: 'Bash',
+        tool_use_id: 't-m2',
+        tool_input: { command: 'gh pr merge 123 --squash' },
+      },
+      dir,
+    );
+    await runHook(
+      'telemetry-capture.mjs',
+      {
+        cwd: dir,
+        hook_event_name: 'PostToolUse',
+        tool_name: 'Bash',
+        tool_use_id: 't-m3',
+        tool_input: { command: 'git merge feat-z' },
+        tool_response: { is_error: true }, // explicit failure → no event
+      },
+      dir,
+    );
+    cliJson(['register', '--as', 'rider'], dir);
+    const events = cliJson<Ev[]>(['events'], dir);
+    expect(events).toHaveLength(2);
+    expect(events[0]!.attrs).toMatchObject({ source: 'feat-y' });
+    expect(events[1]!.attrs).toMatchObject({ pr: '123' });
+  });
+
+  it('the same tool call double-hooked (two settings scopes) records ONE event; distinct calls record two', async () => {
+    const dir = await trackedRepo();
+    const payload = {
+      cwd: dir,
+      hook_event_name: 'PostToolUse',
+      tool_name: 'Bash',
+      tool_use_id: 't-dup',
+      tool_input: { command: 'git merge feat-x' },
+    };
+    await runHook('telemetry-capture.mjs', payload, dir); // scope 1
+    await runHook('telemetry-capture.mjs', payload, dir); // scope 2, same tool call
+    cliJson(['register', '--as', 'rider'], dir);
+    expect(cliJson<Ev[]>(['events'], dir)).toHaveLength(1);
+
+    // a genuinely distinct call moments later still counts
+    await runHook('telemetry-capture.mjs', { ...payload, tool_use_id: 't-dup2' }, dir);
+    cliJson(['register', '--as', 'rider2'], dir);
+    expect(cliJson<Ev[]>(['events'], dir)).toHaveLength(2);
+  });
+
+  it('double-hooked twins split across two flushes still read as ONE event', async () => {
+    const dir = await trackedRepo();
+    const payload = {
+      cwd: dir,
+      hook_event_name: 'PostToolUse',
+      tool_name: 'Bash',
+      tool_use_id: 't-x',
+      tool_input: { command: 'git merge feat-x' },
+    };
+    await runHook('telemetry-capture.mjs', payload, dir);
+    cliJson(['register', '--as', 'rider'], dir); // twin 1 ships in batch 1
+    await runHook('telemetry-capture.mjs', payload, dir);
+    cliJson(['register', '--as', 'rider2'], dir); // twin 2 ships in batch 2
+    expect(cliJson<Ev[]>(['events'], dir)).toHaveLength(1); // read-time dedup spans batches
   });
 
   it('session start spools; session end flushes without waiting for a ride', async () => {
@@ -210,5 +350,6 @@ describe('telemetry capture hooks (issue #100)', () => {
     expect(ctx).toContain('YOU self-report');
     expect(ctx).toContain('after skill "thermo-*": record whether it uncovered bugs');
     expect(ctx).toContain('agentcomm emit --type skill-outcome --name thermo-*');
+    expect(ctx).toContain('if a script already reported it, do not emit a duplicate');
   });
 });

--- a/test/telemetry-precision.test.ts
+++ b/test/telemetry-precision.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Unit tables for the telemetry precision layer: real-merge parsing (no
+ * plumbing false positives), prompt path extraction for worktree-aware
+ * agent refs, and event dedup (re-derivations of one occurrence collapse;
+ * genuine repeats survive).
+ */
+import { describe, it, expect } from 'vitest';
+import { parseMergeCommand, extractAbsolutePaths } from '../src/hook-run.js';
+import { dedupeEvents, eventDedupKey, DEDUP_WINDOW_MS, type TelemetryEvent } from '../src/telemetry.js';
+
+describe('parseMergeCommand', () => {
+  it.each([
+    ['git merge feat-x', { kind: 'git-merge', source: 'feat-x' }],
+    ['git checkout main && git merge feat-x', { kind: 'git-merge', source: 'feat-x' }],
+    ['git merge --no-ff -m "landing it" feat-y', { kind: 'git-merge', source: 'feat-y' }],
+    ['git merge --continue', { kind: 'git-merge' }],
+    ['git merge feat-x && npm test', { kind: 'git-merge', source: 'feat-x' }],
+    ['gh pr merge 123 --squash', { kind: 'gh-pr-merge', pr: '123' }],
+    ['gh pr merge --squash 123', { kind: 'gh-pr-merge', pr: '123' }],
+    ['gh pr merge #77 --auto', { kind: 'gh-pr-merge', pr: '77' }],
+    ['gh pr merge https://github.com/o/r/pull/456 --squash', { kind: 'gh-pr-merge', pr: '456' }],
+    ['gh pr merge --squash', { kind: 'gh-pr-merge' }],
+  ])('%s → merge', (command, expected) => {
+    expect(parseMergeCommand(command)).toEqual(expected);
+  });
+
+  it.each([
+    'git merge-base --fork-point main HEAD',
+    'git merge-base origin/main HEAD',
+    'git merge-tree A B',
+    'git merge-file ours base theirs',
+    'git mergetool',
+    'git merge --abort',
+    'git merge --quit',
+    'gh pr view 123 --json state,mergeCommit,mergedAt',
+    'git log --merges --oneline',
+    'echo git mergetool docs',
+    'echo mergeCommit',
+    'git branch --merged',
+  ])('%s → null (not a merge)', (command) => {
+    expect(parseMergeCommand(command)).toBeNull();
+  });
+
+  it('a merge after a plumbing call in one compound line still counts', () => {
+    expect(parseMergeCommand('git merge-base main HEAD; git merge feat-z')).toEqual({
+      kind: 'git-merge',
+      source: 'feat-z',
+    });
+  });
+});
+
+describe('extractAbsolutePaths', () => {
+  it('extracts, strips trailing punctuation, dedupes, orders deepest-first', () => {
+    const paths = extractAbsolutePaths(
+      'Review /tmp/wt/src/deep/file.ts, then check /tmp/wt (the worktree). Also /tmp/wt/src/deep/file.ts again.',
+    );
+    expect(paths).toEqual(['/tmp/wt/src/deep/file.ts', '/tmp/wt']);
+  });
+
+  it('caps the candidate list', () => {
+    const text = Array.from({ length: 20 }, (_, i) => `/p${i}/x`).join(' ');
+    expect(extractAbsolutePaths(text)).toHaveLength(8);
+  });
+
+  it('ignores bare slashes and relative paths', () => {
+    expect(extractAbsolutePaths('a / b and src/foo.ts here')).toEqual([]);
+  });
+});
+
+describe('dedupeEvents', () => {
+  const ev = (over: Partial<TelemetryEvent>): TelemetryEvent => ({
+    id: Math.random().toString(36).slice(2, 10),
+    ts: '2026-07-23T10:00:00.000Z',
+    agent: 'a-1',
+    session: 's-1',
+    type: 'merged',
+    attrs: { command: 'git merge feat-x' },
+    ...over,
+  });
+  const at = (ms: number) => new Date(Date.parse('2026-07-23T10:00:00.000Z') + ms).toISOString();
+
+  it('collapses identical twins within the window (keep-first), keeps repeats beyond it', () => {
+    const twins = [ev({ ts: at(0) }), ev({ ts: at(150) })];
+    expect(dedupeEvents(twins)).toHaveLength(1);
+    expect(dedupeEvents(twins)[0]!.ts).toBe(at(0));
+
+    expect(dedupeEvents([ev({ ts: at(0) }), ev({ ts: at(DEDUP_WINDOW_MS + 1) })])).toHaveLength(2);
+  });
+
+  it('a burst of N twins collapses to the earliest one', () => {
+    expect(dedupeEvents([ev({ ts: at(0) }), ev({ ts: at(100) }), ev({ ts: at(9_000) })])).toHaveLength(1);
+  });
+
+  it('any identity field difference keeps both', () => {
+    expect(dedupeEvents([ev({}), ev({ agent: 'a-2' })])).toHaveLength(2);
+    expect(dedupeEvents([ev({}), ev({ session: 's-2' })])).toHaveLength(2);
+    expect(dedupeEvents([ev({}), ev({ ref: 'feat-x' })])).toHaveLength(2);
+    expect(dedupeEvents([ev({}), ev({ attrs: { command: 'git merge feat-y' } })])).toHaveLength(2);
+  });
+
+  it('distinct tool calls survive even inside the window (tool_use in attrs differs)', () => {
+    const a = ev({ ts: at(0), attrs: { command: 'git merge feat-x', tool_use: 't-1' } });
+    const b = ev({ ts: at(100), attrs: { command: 'git merge feat-x', tool_use: 't-2' } });
+    expect(dedupeEvents([a, b])).toHaveLength(2);
+  });
+
+  it('key is insensitive to attrs key order', () => {
+    const a = ev({ attrs: { x: 1, y: { b: 2, a: 3 } } });
+    const b = ev({ attrs: { y: { a: 3, b: 2 }, x: 1 } });
+    expect(eventDedupKey(a)).toBe(eventDedupKey(b));
+  });
+});


### PR DESCRIPTION
Three defects in the deterministic telemetry layer made recorded events unreliable for downstream analysis; all three are fixed with tests that go red when each fix is reverted.

## 1. `merged` events fired on non-merges
`/git\s+merge\b/` matches `git merge-base`, `git merge-tree`, `git merge-file` — a hyphen is a word boundary. Real telemetry accumulated dozens of plumbing false-positives.
- New `parseMergeCommand()`: only real `git merge <ref>` / `gh pr merge` count; `--abort`/`--quit` (unwinding a merge) are excluded.
- Events now carry the merged **source branch** (`attrs.source`) or **PR number** (`attrs.pr`) for correlation.
- A tool call the harness clearly marked as failed (`is_error: true` / `success: false`) is skipped; absent/unknown response shapes still emit.

## 2. `agent-ran` recorded the wrong branch
The event fires in the session that *spawned* the subagent; `git -C <session cwd> branch --show-current` names the primary checkout's branch even when the reviewed work lives in a sibling worktree — in observed data, ~85% of events landed on the default branch. New `resolveAgentRef()` scans the subagent prompt for absolute paths (capped, timeout-bounded, never throws), resolves the containing checkout's branch deepest-first preferring non-default names, and falls back to the cwd branch. Provenance is recorded as `attrs.ref_source: 'prompt-path' | 'cwd'` so readers can discount cwd-derived refs.

## 3. Duplicate events
The same hook registered in two settings scopes (user + project) runs twice per tool call; each spawn minted an identical event with a fresh id/ts, and nothing anywhere deduped (observed: ~28% of one event type were byte-identical twins).
- Events now carry the harness `tool_use_id` (`attrs.tool_use`) when present, making identity **exact**: same tool call → twin; parallel same-shaped calls → distinct, kept.
- `dedupeEvents()` (identity = everything but id/ts, 10s window, keep-first) runs at **flush** (store stays clean) and at **read** (collapses twins split across batches — and retroactively heals stores written before this fix).

Also: the session-start briefing now notes that repos may emit outcomes automatically from their own scripts, so agents don't double-report.

## Verification
- 43 tests across `telemetry-precision.test.ts` (new unit tables) + `telemetry-hooks.e2e.test.ts` (extended).
- Mutation-verified, both directions: old regex restored → plumbing guard red; ref resolution forced to cwd → worktree guard red; dedup disabled → twin guards red; fixes restored → all green.
- Full hook/telemetry/daemon/git/cli suites green (two daemon/git timeouts under heavy machine load reproduced on a quiet run as green — load flake, not code).

Release prep: version bumped to 0.19.2; cut with `gh workflow run release-cut.yml -f version=current` after merge.