### PR TITLE
docs: cover on:agent + v0.19.2 telemetry precision in README and website

### DIFF
--- a/README.md
+++ b/README.md
@@ -478,6 +478,8 @@ telemetry:
     - on: skill
       match: my-review-skill
       record: "whether it uncovered bugs, findings count, iteration for the branch"
+    - on: agent                 # skills that run as dedicated subagents
+      match: my-review-agent
     - on: merge
   # retention: 180d      # opt-in; default keeps everything
 ```
@@ -495,6 +497,19 @@ the session briefing injects each rule's `record:` text so the model knows
 what to self-report. The `on`/`match` layer never depends on the model —
 if it's in the config, it fires. (Only task-list tracking differs: Codex
 and OpenCode have no task events.)
+
+Capture is precise about what it records. `merged` events fire only for
+real `git merge` / `gh pr merge` invocations — plumbing like `merge-base`
+and unwinding via `merge --abort` don't count, commands the harness marked
+as failed are skipped — and they carry the merged source branch or PR
+number in `attrs`. `agent-ran` events resolve their `ref` from worktree
+paths named in the subagent prompt (the session's own cwd often sits on
+the default branch while the work happens in a sibling worktree), falling
+back to the cwd branch, with provenance in `attrs.ref_source`. And when a
+harness fires the same hook twice for one occurrence — the same hook
+registered in two settings scopes is the common case — the twins collapse:
+events dedup on identity within a 10-second window at both flush and read
+time.
 
 Recording is free at capture time: `agentcomm emit --type skill-outcome
 --name my-review-skill --ref "$(git branch --show-current)" --attrs

--- a/docs/index.html
+++ b/docs/index.html
@@ -290,6 +290,7 @@ agentcomm hooks --harness opencode">Copy</button>
         <div class="line">  "telemetry": { "track": [</div>
         <div class="line">    { "on": "skill", "match": "code-review",</div>
         <div class="line">      "record": "whether it uncovered bugs, and the findings count" },</div>
+        <div class="line">    { "on": "agent", "match": "code-review-*" },</div>
         <div class="line">    { "on": "merge" }</div>
         <div class="line">  ] }</div>
         <div class="line">}</div>
@@ -314,8 +315,11 @@ agentcomm hooks --harness opencode">Copy</button>
           answers questions like <em>“how many runs of our review skill uncovered
           bugs — and how many iterations before we merge?”</em>. Opt-in per repo and
           deterministic: declare what to track in the config above, and it fires —
-          hooks record the facts (a tracked skill ran, a merge happened), the model
-          self-reports the judgments the config's <code>record:</code> text asks for.
+          hooks record the facts (a tracked skill ran, a tracked subagent was
+          spawned, a merge happened), the model self-reports the judgments the
+          config's <code>record:</code> text asks for. Skills that run as dedicated
+          subagents are invisible to the skill trigger — track those with
+          <code>on: agent</code>, matched by subagent type.
         </p>
       </div>
       <div class="grid reveal">
@@ -326,7 +330,7 @@ agentcomm hooks --harness opencode">Copy</button>
         <div class="card"><span class="cmd">keep everything</span>
           <p>No cleanup by default. Events are the analysis substrate and registrations are their join table — aging anything out is an explicit <code>purge --events</code> / <code>telemetry.retention</code> decision.</p></div>
         <div class="card"><span class="cmd">analysis is an agent</span>
-          <p><code>agentcomm events --json</code> hands the raw lane to whoever asks the question — counting, grouping, and joining runs to merges by branch <code>ref</code> is an in-context job.</p></div>
+          <p><code>agentcomm events --json</code> hands the raw lane to whoever asks the question — counting, grouping, and joining runs to merges by branch <code>ref</code> is an in-context job. Merged events carry the source branch or PR number in <code>attrs</code>; duplicate hook firings dedup automatically.</p></div>
       </div>
       <div class="codeblock reveal" style="max-width:640px; margin-top:28px;">
         <div class="line out"># the agent self-reports the outcome the config asked for</div>

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -49,7 +49,7 @@ export const EVENTS_PREFIX = 'events/';
 
 /** A declarative capture rule from the repo config — if it's listed, it fires. */
 export interface TelemetryTrackRule {
-  /** Deterministic trigger: 'skill' | 'tool' | 'session' | 'task' | 'merge' (open vocabulary). */
+  /** Deterministic trigger: 'skill' | 'agent' | 'tool' | 'session' | 'task' | 'merge' (open vocabulary). */
   on: string;
   /** Optional name filter for the trigger (a skill name, a tool glob). */
   match?: string;


### PR DESCRIPTION
Review of v0.19.2 (#147) found the docs trailing the code:

- **Website** (`docs/index.html`): the telemetry section never got the `on: agent` trigger — config example and prose still said skill+merge only. Added the trigger to both, plus a line on merge `attrs` and automatic dedup in the analysis card.
- **README**: the YAML example lacked `on: agent` (prose had it), and none of the v0.19.2 precision behaviors were documented. Added the trigger to the example and a paragraph covering exact merge parsing, merged-event `attrs` (source branch / PR), `attrs.ref_source` provenance on `agent-ran`, and the 10s twin dedup.
- **`src/telemetry.ts`**: the `TelemetryTrackRule.on` vocabulary docstring listed every trigger except `'agent'`.

Docs/docstring only — no behavior change. Both telemetry test suites pass locally (43/43).

🤖 Generated with [Claude Code](https://claude.com/claude-code)