### PR TITLE
docs: cut the README and site to intent, move the depth behind links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,65 @@
+# Contributing
+
+```bash
+npm install                 # dev toolchain incl. all backend drivers (devDependencies)
+npm run typecheck
+npm test                    # vitest: backend contract, bus, CLI e2e, WAL/Postgres concurrency
+npm run build               # emit dist/
+```
+
+## Tests that need live services
+
+The S3, GCS and Postgres suites (`test/s3.test.ts`, `test/gcs.test.ts`,
+`test/postgres.test.ts`) need live services — each skips itself with a console
+warning when its service is unreachable. One command brings everything up
+([Garage](https://garagehq.deuxfleurs.fr/), an S3-compatible object store written
+in Rust; fake-gcs-server; and Postgres — buckets and keys provisioned by
+`test/e2e/setup.sh` with fixed throwaway credentials):
+
+```bash
+npm run test:e2e:up    # docker compose up + provision buckets/keys
+npm test               # now runs ALL suites, nothing skipped
+npm run test:e2e:down  # tear down (removes volumes)
+# point at other services with AGENTCOMM_TEST_S3_ENDPOINT,
+# AGENTCOMM_TEST_GCS_ENDPOINT or AGENTCOMM_TEST_POSTGRES_URL
+```
+
+The `github://` suite (`test/github.test.ts`) targets a real repo on a scratch
+branch, deleted afterwards — gate it with
+`AGENTCOMM_TEST_GITHUB_REPO=you/yourrepo` (your `gh` login is enough). In CI it
+runs against **this repository itself** using the workflow's token.
+
+CI (`.github/workflows/ci.yml`) runs this same flow on every push and PR, so all
+seven backends are exercised end-to-end.
+
+### What the suite proves
+
+The same backend-contract and bus tests run against every backend (the git suite
+runs against local bare repos, so its full fetch/plumbing/push path needs no
+services), plus concurrency tests proving: WAL lets independent SQLite writers
+proceed; N concurrent processes calling `claim` on one shared queue (SQLite or
+Postgres) get disjoint messages, none dropped, none double-delivered; and `wait`
+on Postgres resolves within tens of ms of a `send` from a **separate OS process**
+(real push via `LISTEN/NOTIFY`, not a poll interval). CLI end-to-end tests cover
+the `wait` exit codes, the `claim` error/empty/success paths, the
+`AGENTCOMM_BACKEND_PLUGINS` loading mechanism, and the missing-driver error path.
+
+## Releasing
+
+Two moves. First the version bump lands as a normal PR (main is protected, so this
+rides the required CI check like any change): `npm version X.Y.Z
+--no-git-tag-version`, committed. Then one dispatch releases the tree `main`
+carries:
+
+```bash
+gh workflow run release-cut.yml -f version=current   # or X.Y.Z as a guard
+```
+
+The workflow is commit-free on main: it verifies the version guard, sanity-tests,
+tags, publishes the GitHub Release with generated notes, and hands off to
+`release.yml`, which publishes to the **npm registry** (trusted publishing / OIDC,
+with provenance — no token secret) and attaches the fallback install artifacts —
+the versioned `agentcomm-X.Y.Z.tgz` plus the constant-named `agentcomm-latest.tgz`
+that keeps `releases/latest/download/agentcomm-latest.tgz` always-newest. No docs
+follow-up: everything points at `@yonidavidson/agentcomm@latest` or the constant
+URL.

--- a/README.md
+++ b/README.md
@@ -1,703 +1,111 @@
 # agentcomm
 
-🌐 **[Website](https://yonidavidson.github.io/agentcomm/)** · [Use cases](https://yonidavidson.github.io/agentcomm/#use-cases) · [Live demo — an agent conversation that *is* a git branch](https://github.com/yonidavidson/agentcomm/tree/agentcomm) · [Install](#install) · [Your harness](#your-harness-claude-code--codex--opencode)
+🌐 **[Website](https://yonidavidson.github.io/agentcomm/)** · [Use cases](https://yonidavidson.github.io/agentcomm/#use-cases) · [Live demo — an agent conversation that *is* a git branch](https://github.com/yonidavidson/agentcomm/tree/agentcomm)
 
-A tiny mailbox / message bus for AI agents that shell out to one CLI. Agents
-`register`, `send`, and read their `inbox`; a single `Backend` interface hides
-where the messages live. **Any git remote is a bus** — the git backends need
-no driver at all; local runs need zero dependencies; everything else is an
-optional, lazy-loaded driver.
-
-## If you are an AI agent reading this
-
-Get yourself (and this repo) on the bus — takes under a minute, and it is
-the SAME three commands whatever harness you are:
-
-```bash
-npm install -g @yonidavidson/agentcomm
-agentcomm hooks --harness claude     # or codex / opencode — writes your lifecycle hooks
-agentcomm init --harness claude      # or codex / opencode — writes the team contract
-```
-
-`hooks` wires your harness's lifecycle to the CLI (auto-register at session
-start, inbox digests, the stop guard); `init` writes the coordination
-contract into `CLAUDE.md` (Claude Code) or `AGENTS.md` (everyone else) and
-registers you. You often don't even need the `hooks` step — any bus command
-run in an opted-in repo provisions missing hooks itself. Check for updates
-once a session: `agentcomm version` compares your install against the latest
-release and prints the upgrade command when you're behind.
-
-```
-            ┌─────────────────────────────────────────────┐
- agents ──▶ │  agentcomm CLI  (one stable interface)        │
-            │      │                                         │
-            │      ▼                                         │
-            │  Backend interface  ◀── the seam               │
-            │   ├─ GitBackend      — ANY git remote is a bus │
-            │   ├─ GithubBackend   — GitHub via token (no ssh)│
-            │   ├─ LocalBackend    — zero-dep default         │
-            │   ├─ SqliteBackend   — single box, WAL          │
-            │   ├─ S3Backend       — object store             │
-            │   ├─ GCSBackend      — object store             │
-            │   └─ PostgresBackend — distributed, push        │
-            └─────────────────────────────────────────────┘
-```
+A tiny mailbox for AI agents. Agents `register`, `send`, and read their `inbox`
+through one CLI; a single `Backend` interface hides where the messages live.
+**In a git repo you are already on the bus** — the repo's remote is the transport,
+no server, no config, no dependencies.
 
 ## Install
 
-Straight from the npm registry, for **every** harness, script, and
-automation:
-
 ```bash
 npm install -g @yonidavidson/agentcomm
+agentcomm hooks --harness claude     # or codex / opencode — wires your session lifecycle
+agentcomm init                       # writes the team contract, registers you, shows the roster
 ```
 
-That is the whole thing: ~100 kB, zero runtime dependencies for the file/git
-backends, no plugin, no marketplace, no skill to install. Upgrade with
-`npm install -g @yonidavidson/agentcomm@latest` — `agentcomm version` tells you when. Pin
-with `agentcomm@X.Y.Z`.
+`hooks` wires the harness lifecycle to the CLI (auto-register at session start,
+inbox digests, the stop guard); `init` writes the coordination contract into
+`CLAUDE.md` (Claude Code) or `AGENTS.md` (everyone else). Any bus command
+auto-provisions missing hooks, so the `hooks` step is usually optional.
+`agentcomm version` tells you when to upgrade.
 
-No registry access? The same tarball is attached to every
-[GitHub release](https://github.com/yonidavidson/agentcomm/releases), and one
-URL always serves the newest:
-`npm install -g https://github.com/yonidavidson/agentcomm/releases/latest/download/agentcomm-latest.tgz`.
-
-To embed the library as a **dependency**:
-
-```bash
-npm install @yonidavidson/agentcomm
-
-# git+ssh:// / git+https:// / github:// / file:// need NOTHING more
-# (Node ≥ 18; the git binary for git+; a token for github://).
-# Per-backend drivers, only if you use that backend — the CLI names the
-# exact package when one is missing:
-npm install better-sqlite3            # sqlite://
-npm install @aws-sdk/client-s3        # s3://
-npm install @google-cloud/storage     # gs://
-npm install pg                        # postgres://
-npm install yaml                      # only for .agentcomm.yaml config files (.json needs nothing)
-```
-
-### Programmatic use (SDK)
-
-Everything the CLI does rides the same library entry point — another system
-can join the bus without shelling out:
-
-```ts
-import { Bus, createBackend } from '@yonidavidson/agentcomm';
-
-const backend = await createBackend('sqlite:///var/run/team-bus.db');
-const bus = new Bus(backend);
-
-await bus.register('dashboard', undefined, 'watching the release train');
-await bus.send({ from: 'dashboard', to: 'reviewer', subject: 'status', body: 'CI is green' });
-const mail = await bus.inbox('dashboard'); // consuming read, like the CLI
-```
-
-`createBackend` accepts every URI the CLI does (`git+ssh://`, `github://`,
-`file://`, `sqlite://`, `s3://`, `gs://`, `postgres://`), and
-`registerBackend()` adds new schemes — see [Writing a backend plugin](#writing-a-backend-plugin).
-The full surface (conventions, channel discovery, telemetry, identity
-helpers) is exported from the package root; `src/index.ts` is the contract.
-
-## Your harness (Claude Code · Codex · OpenCode)
-
-One integration model everywhere: `agentcomm hooks --harness <name>`
-generates the file that wires your harness's lifecycle to the global CLI —
-session start registers you and briefs the session, prompt/mid-turn digests
-surface bus news, the stop guard holds the session while unread mail waits.
-The generated files are committed to the repo, so the whole team is wired by
-the first person who runs it — and any bus command auto-provisions them when
-they're missing (`AGENTCOMM_NO_AUTO_HOOKS=1` opts out).
-
-### With Claude Code
-
-```bash
-agentcomm hooks --harness claude     # writes hooks into .claude/settings.json
-agentcomm init                       # writes CLAUDE.md, registers, shows the roster
-```
-
-The hooks merge into existing project settings without touching anything
-else. Claude Code asks once to approve project hooks — accept, and the whole
-lifecycle (register, digests, stop guard, task-list → bus status, telemetry
-capture) runs through `agentcomm hook <event>`.
-
-### With Codex
-
-```bash
-agentcomm hooks --harness codex      # writes .codex/hooks.json
-agentcomm init --harness codex       # writes AGENTS.md, registers, shows the roster
-```
-
-Codex requires explicit trust for hooks: open `/hooks`, review the agentcomm
-entries, and trust them. Same lifecycle as Claude Code minus the task-list
-status mirroring (Codex has no task events).
-
-### With OpenCode
-
-[OpenCode](https://opencode.ai) runs on Bun and reads `AGENTS.md` natively, so
-its agents already onboard from this repo's `AGENTS.md`:
-
-```bash
-agentcomm hooks --harness opencode     # writes .opencode/plugin/agentcomm.ts
-agentcomm init --harness opencode      # writes AGENTS.md, registers, shows the roster
-```
-
-The generated file is a plain OpenCode plugin that shells out to the global
-CLI — commit it and every OpenCode session in this repo joins the bus. It is
-small enough to read in full, and yours to edit:
-
-```ts
-// .opencode/plugin/agentcomm.ts (generated — abridged)
-import type { Plugin } from '@opencode-ai/plugin';
-
-export const AgentcommHooks: Plugin = async ({ directory, client, $ }) => {
-  const sh = $.cwd(directory).nothrow();
-
-  // Session start: join the repo bus under a session-unique alias.
-  await sh`agentcomm register --status "opencode session"`.quiet();
-
-  return {
-    // session.idle can't block, so unread mail re-prompts the session.
-    async event({ event }) {
-      if (event.type !== 'session.idle') return;
-      const peek = await sh`agentcomm peek --json`.quiet();
-      // …parses the inbox and re-prompts the session when mail is waiting…
-    },
-    // Telemetry parity with the other harnesses: tool events are normalized
-    // and handed to `agentcomm hook telemetry`, which owns the repo's
-    // telemetry.track rule matching; dispose() ships the event spool.
-    async 'tool.execute.after'(input) {
-      // …skill / task / bash(merge) → agentcomm hook telemetry…
-    },
-    async dispose() {
-      // …agentcomm emit --flush…
-    },
-  };
-};
-```
-
-That same shape is how you'd wire any other hook to the bus — e.g. a
-handler that `agentcomm send`s a teammate when a long task finishes.
-(OpenCode's `session.idle` can't block, so its inbox guard nudges instead of
-holding the session the way the Claude Code stop guard does.)
-
-> An earlier plugin system (Claude Code/Codex marketplaces, an in-process
-> OpenCode plugin) is fully retired — the CLI is the entire integration. A
-> legacy pinned `.tgz` in `opencode.json` keeps working and suppresses hook
-> generation, but new setups use the commands above.
+~100 kB, zero runtime dependencies for the file/git backends. No registry access?
+`npm install -g https://github.com/yonidavidson/agentcomm/releases/latest/download/agentcomm-latest.tgz`
+always serves the newest build.
 
 ## Quick start
 
 ```bash
-# in a git repo: zero config. You're on the repo bus under a session-unique
-# alias; init defaults to Claude Code and writes CLAUDE.md.
+# in a git repo: zero config. You're on the repo bus under a session-unique alias.
 agentcomm init                      # → acting as yoni-3f2a · on the bus: git+ssh://…
-# Codex uses its own repo guidance file.
-agentcomm init --harness codex      # → AGENTS.md created
 agentcomm agents                    # who's here: yoni-3f2a · dana-97b1 · ci-bot
 agentcomm send ci-bot "hold deploys" --subject status
 
-# named ROLES (addressable, stable) take --as; register warns if the alias
-# is live in another session
+# named ROLES (addressable, stable) take --as
 agentcomm register --as reviewer
 agentcomm send reviewer "review src/auth.ts" --subject task --thread auth-1
-agentcomm inbox --as reviewer --json     # consumes; archives under read/
+agentcomm inbox --as reviewer --json            # consumes; archives under read/
 agentcomm wait  --as reviewer --timeout 30000   # exit 0 on delivery, 2 on timeout
 
-# shared-worker-queue pattern (multiple workers, one queue) — git + SQL backends
+# one queue, many workers (git + SQL backends)
 agentcomm send work-queue "task-1" --subject task
 agentcomm claim --queue work-queue --as worker-1   # atomic; null when empty
-
-# other stores when topology calls for it (push wait, SQL claims):
-export AGENTCOMM_BACKEND=postgres://user:pass@host:5432/agentcomm
-agentcomm wait --as reviewer --timeout 30000   # resolves within ~ms via LISTEN/NOTIFY
 ```
 
-`send`/`broadcast` read the body from the trailing argument, or from **stdin**
-if omitted:
-
-```bash
-echo "from a pipe" | agentcomm send bob --as alice
-```
-
-### Point a project at another repo's bus
-
-Some things that talk on the bus don't live in the bus repo — a dashboard, a
-cron job, a sibling project. A **repo pointer** resolves the bus as if the CLI
-ran inside another checkout (its `.agentcomm` config, its git remote, its
-`file://` fallback), with the usual flag > env > config precedence:
-
-```bash
-agentcomm agents --repo ~/dev/team-bus        # one-off
-export AGENTCOMM_REPO=~/dev/team-bus          # per process
-echo '{ "repo": "~/dev/team-bus" }' > .agentcomm.json   # committed: this
-                                              # project talks on THAT bus
-```
-
-One hop only (a pointer inside the target is an error), and an explicit
-`--backend`/`AGENTCOMM_BACKEND` always wins. This is how
-[agentcomm-arcade](https://github.com/yonidavidson/agentcomm-arcade) watches a
-bus from outside its repo.
-
-## What people build with it
-
-- **Agents sharing a repo, talking through it** — the repo is the bus: repo
-  permissions are the ACL, every message is a commit you can watch.
-- **Cloud + local worker fleets** splitting one queue with atomic `claim`.
-- **A CD pipeline you can ask** "what's the status of the build?" mid-deploy.
-- **IoT edge agents** — a camera answering "what do you see?", weather sensors
-  reporting humidity to one `broadcast` — on nothing but outbound HTTPS.
-- **Claude Code, Codex, and OpenCode pairing on one machine** — each harness
-  uses its own guidance file while all of them communicate over the same
-  repo bus through the one CLI.
-- **A dashboard watching the bus** —
-  [agentcomm-arcade](https://github.com/yonidavidson/agentcomm-arcade) renders
-  the roster, feed, and telemetry as a pixel/CRT guild hall by shelling out to
-  the same CLI; the worked example for putting your own UI on the bus.
-
-All illustrated with runnable commands on the
-[use-cases page](https://yonidavidson.github.io/agentcomm/#use-cases) — plus
-why the security story is *subtraction*: your storage's auth is the bus's auth.
+`send`/`broadcast` take the body from the trailing argument or from **stdin**:
+`echo "from a pipe" | agentcomm send bob`.
 
 ## Commands
 
-| Command            | What it does                                                        |
-| ------------------ | ------------------------------------------------------------------- |
-| `init`             | Put this repo on the bus: writes `CLAUDE.md` by default, or `AGENTS.md` with `--harness codex\|opencode\|agents`, registers you, and shows the roster. Commit the selected harness file. |
-| `register`         | Register / heartbeat the calling agent (`--as`).                    |
-| `version` / `-v`   | Installed version + the latest release, compared; prints `npm install -g @yonidavidson/agentcomm@latest` when an update exists. Agents: run once per session to stay current. |
-| `agents`           | List registered agents.                                             |
-| `send <to> [body]` | Send a message (body from arg or stdin).                            |
-| `broadcast [body]` | Send to every registered agent except yourself.                    |
-| `inbox`            | **Consume** undelivered messages; archives them under `read/`.      |
-| `peek`             | Show undelivered messages **without** consuming.                    |
-| `wait`             | Block until a message arrives (**exit 0**) or timeout (**exit 2**). |
-| `claim`            | Atomically dequeue one message from `--queue` (**git + SQL backends**). |
-| `describe`         | Explain the `--backend` scheme: how channels are carved from the URI, and its capabilities. **Static** — never loads a driver or connects. |
-| `channels`         | List the channels that already exist on the `--backend` store (scans for the agentcomm key layout; needs the driver + credentials). |
-| `purge`            | Delete archived (`read/`) messages older than `--older-than`, and/or telemetry events older than `--events` (or the config's `telemetry.retention`). Pending mail is never touched; registrations are **never** purged (presence is heartbeat-derived, and telemetry events reference them). The daemon trims the archive automatically (30d default). |
-| `log`              | Read a channel's conversation — pending + archived, time-ordered, **non-consuming**, no `--as` needed. `--thread`, `--limit`. |
-| `network`          | Situation report — who's on the bus now (active vs idle), their status, and recent traffic. Read-only. In Claude Code: `/agentcomm:network`. |
-| `conventions`      | Print the effective team conventions (built-in defaults ⊕ `.agentcomm.json`/`.yaml` override). Static — never connects. In Claude Code, `/agentcomm:config` explains and edits the whole config file interactively. |
-| `emit`             | Record a [telemetry event](#telemetry-events--the-append-only-lane) (`--type`, `--name`, `--ref`, `--attrs '<json>'`). Spools locally and rides the next bus write; `--flush` ships now. Inert unless the repo config opts in. |
-| `events`           | Read telemetry events (`--type`/`--name`/`--ref`/`--since <dur>`/`--limit`; `--json` for analysis). |
-
-### Flags
-
-| Flag               | Meaning                                                        |
+| Command            | What it does                                                   |
 | ------------------ | -------------------------------------------------------------- |
-| `--backend <uri>`  | Backend URI. Default resolution: flag > `AGENTCOMM_BACKEND` > `.agentcomm` config > `git+<origin>` probe > `github://` token fallback > `file://./.agentcomm`. |
-| `--as <name>`      | Acting alias (env `AGENTCOMM_AGENT`). Defaults to `<git-identity>-<session>` (a 4-char per-session id — concurrent runners on one machine get distinct mailboxes; set `AGENTCOMM_SESSION` to pin it). **Names are aliases** — addressing, not authentication; on git backends the commit author in `git log` is the verifiable identity. |
-| `--subject <text>` | Message subject (`send`/`broadcast`).                          |
-| `--thread <id>`    | Thread id (`send`/`broadcast`).                                |
-| `--timeout <ms>`   | `wait` timeout in ms (default `30000`).                        |
-| `--queue <name>`   | Queue to claim from (`claim`) — same namespace as a recipient inbox. |
-| `--older-than <dur>` | Age threshold for `purge` (`45s`, `30m`, `12h`, `30d`).      |
-| `--events <dur>`   | `purge`: age out telemetry event batches older than this (opt-in; `telemetry.retention` in the config also applies). |
-| `--dry-run`        | `purge` only lists what it would delete.                       |
-| `--type/--name/--ref` | `emit`/`events`: event type, subject name, correlation handle. |
-| `--attrs <json>`   | `emit`: free-form JSON object payload.                         |
-| `--flush`          | `emit`: ship the spool now instead of riding the next write.   |
-| `--since <dur>`    | `events`: only events newer than e.g. `30d`.                   |
-| `--limit <n>`      | `log`: keep the most recent n messages (default 50).           |
-| `--harness <name>` | `init`: select `claude` (default, `CLAUDE.md`) or `codex` (`AGENTS.md`). |
-| `--json`           | Machine-readable JSON output (available on every command).     |
+| `init`             | Put this repo on the bus; writes `CLAUDE.md` (or `AGENTS.md` with `--harness`). |
+| `register`         | Register / heartbeat the calling agent, optionally with `--status`. |
+| `agents`           | List registered agents.                                        |
+| `send <to> [body]` | Send a message (body from arg or stdin).                       |
+| `broadcast [body]` | Send to every registered agent except yourself.                |
+| `inbox`            | **Consume** undelivered messages; archives them under `read/`.  |
+| `peek`             | Show undelivered messages **without** consuming.               |
+| `wait`             | Block until a message arrives (**exit 0**) or timeout (**exit 2**). |
+| `claim`            | Atomically dequeue one message from `--queue` (git + SQL backends). |
+| `log`              | Read a channel's conversation, time-ordered and non-consuming.  |
+| `network`          | Situation report: who's on the bus, their status, recent traffic. |
+| `channels`         | List the channels that already exist on a store.               |
+| `describe`         | Explain a backend scheme and its capabilities. Never connects.  |
+| `conventions`      | Print the effective team conventions. Never connects.          |
+| `purge`            | Delete archived mail (`--older-than`) and, opt-in, telemetry events (`--events`). |
+| `emit` / `events`  | Write and read the [telemetry lane](guide/telemetry.md).        |
+| `version` / `-v`   | Installed vs latest release; prints the upgrade command.        |
+
+Key flags: `--backend <uri>` (transport), `--as <name>` (acting alias, env
+`AGENTCOMM_AGENT`), `--subject` / `--thread`, `--timeout`, `--queue`, `--json`
+(every command). `agentcomm <cmd> --help` has the rest.
+
+Backend resolution: `--backend` > `AGENTCOMM_BACKEND` > `.agentcomm` config >
+`git+<origin>` probe > `github://` token fallback > `file://./.agentcomm`.
 
 ## Backends
 
-> **In a git repo, you're already on the network.** With no backend
-> configured, agentcomm probes your `origin` remote: if git can reach it, the
-> bus is `git+<origin>` — **any host**, atomic `claim` included; if only a
-> GitHub token is available, it falls back to `github://owner/repo`. A stderr
-> notice tells you what was picked. Resolution: `--backend` >
-> `AGENTCOMM_BACKEND` > `.agentcomm` config > git probe > github token >
-> `file://./.agentcomm` (`AGENTCOMM_NO_GIT_PROBE=1` skips the probe).
-
 Choose transport by **topology** — that's the only fork that matters.
-
-| Backend     | URI                          | Driver (optional)      | Atomic `move` | `claim` (shared queue) | Push (`wait`) | Use when                         |
-| ----------- | ---------------------------- | ---------------------- | :-----------: | :--------------------: | :-----------: | -------------------------------- |
-| **Local**   | `file:///path/dir`, bare dir | — (built in)           | ✅ (rename)   | ❌                     | poll          | dev, single process, zero deps   |
-| **Git (any host)** | `git+ssh://…/repo.git[?channel=x]` | — (git binary) | ✅ (one commit) | ✅ (push CAS)   | poll          | **any git remote** — GitLab, Gitea, private servers |
-| **GitHub**  | `github://owner/repo[/prefix]` | — (built in)         | ❌ (copy+commit) | ❌                  | poll          | token-mode GitHub variant (CI, API-only environments) |
-| **SQLite**  | `sqlite:///path.db[?channel=x]`, `*.db` | `better-sqlite3` | ✅ (txn)   | ✅ (txn)              | poll          | **single machine** (recommended) |
-| **S3**      | `s3://bucket/prefix`         | `@aws-sdk/client-s3`   | ❌ (copy+del) | ❌                     | poll          | shared object store              |
-| **GCS**     | `gs://bucket/prefix`         | `@google-cloud/storage`| ❌ (copy+del) | ❌                     | poll          | shared object store              |
-| **Postgres**| `postgres://…/db[?channel=x]` | `pg`                | ✅ (txn)      | ✅ `SKIP LOCKED`       | ✅ **push**   | **across machines/containers**   |
-
-**Rule of thumb:**
-
-- **One machine → `sqlite://`.** WAL mode gives you ACID, atomic per-key writes
-  and an atomic `move`, with no daemon. This is the recommended default.
-- **Across machines/containers → `postgres://`** for race-free shared queues
-  (`SKIP LOCKED`) and real push (`LISTEN/NOTIFY`) in one boring dependency.
-
-### The bus daemon — immediate answers on remote buses
-
-A cold CLI call on a network bus pays a round-trip (a git fetch, an API
-call) — fine occasionally, slow as a conversation. So on network schemes
-(`git+ssh://`, `git+https://`, `github://`) the CLI keeps a **bus daemon**:
-one background process per bus URI that polls the remote on its own clock
-(`AGENTCOMM_POLL_MS`, default 10s) and serves commands over a local socket.
-
-- **Same semantics, exactly** — the daemon slots in *under* the `Backend`
-  seam. Reads come from its warm mirror (staleness ≤ the poll interval);
-  **sends ack from a disk-persisted outbox in ~0.2s** and are delivered
-  in order with retries (crash-safe; `--sync` waits for remote durability
-  instead); consumption (`inbox`/`claim`) always confirms against the real
-  store, so atomicity is untouched. `daemon status` shows outbox depth.
-- Autostarted on first use; exits itself after 30 idle minutes. `agentcomm
-  daemon status|stop` to inspect, `--daemon` to force it on any scheme,
-  `--direct` (or `AGENTCOMM_DAEMON=0`) to bypass. If the daemon can't be
-  reached the CLI silently falls back to a direct connection — never worse,
-  only faster.
-
-### Channels — same store, many rooms
-
-A **channel is a connection string**: two agents share a bus iff they pass the
-same `--backend` URI. One store can host many isolated channels — for the
-path-carved backends, just append a segment:
-
-```
-git+ssh://…/repo.git?channel=team-a                       # git: carve by query param
-s3://acme-bus/team-a          s3://acme-bus/team-b        # two isolated buses, one bucket
-file:///shared/bus/team-a     file:///shared/bus/team-b   # same idea on a shared volume
-postgres://…/bus?channel=team-a                           # SQL: carve by query param
-sqlite:///shared/bus.db?channel=team-a                    # (omit ?channel= = root channel)
-```
-
-On SQL backends every channel keeps the full guarantees — atomic `claim` and
-(on Postgres) push `wait` are isolated per channel, and data written without
-`?channel=` stays untouched as the root channel.
-
-Don't memorize the per-scheme rules — ask the CLI:
-
-```bash
-agentcomm describe --backend s3://acme-bus --json
-# → channel rule + template + example, capabilities (claim/push), caveats
-```
-
-And to join existing work, enumerate instead of guessing prefixes:
-
-```bash
-agentcomm channels --backend s3://acme-bus
-# channels on s3://acme-bus (2)
-#   s3://acme-bus/team-a  — 3 agents
-#   s3://acme-bus/team-b  — 1 agent
-```
-
-Channels are **namespacing, not security**: everyone on a store shares its
-credentials. Isolation is enforced by the backend's own access controls —
-and those can be channel-grained (e.g. S3 IAM prefix conditions per team,
-Postgres grants per database).
-
-### Naming & joining — so "work on x" means the same channel to everyone
-
-- **Topic channels**: kebab-case, one workstream each — `github://owner/repo/fix-auth`.
-- **Repo artifacts** (git backend): `issue-<n>` / `pr-<n>` — discussion of
-  issue or PR N has a deterministic home, no coordination needed to find it.
-- **`lobby`**: the well-known meeting room per store — register there,
-  announce which topic channels you're joining, ask who's on what.
-
-These are defaults in code; a project overrides them with an
-`.agentcomm.json` (zero-dep) or `.agentcomm.yaml` (optional `yaml` package)
-file, found upward from the working directory or named by `AGENTCOMM_CONFIG`:
-
-```json
-{
-  "backend": "github://acme/webapp",
-  "conventions": { "lobby": "commons", "subjects": ["plan", "done"] }
-}
-```
-
-(`backend` pins a project-default bus — consumed by the backend resolution
-chain.) Agents never memorize any of this:
-
-```bash
-agentcomm conventions --json                                # the effective rules + their source
-agentcomm log --limit 20 --backend github://acme/webapp/fix-auth   # read the room before speaking
-```
-
-**The join recipe**: `channels` (what exists) → construct/pick the topic URI →
-`register` → `log --limit 20` (catch up on the conversation, non-consuming) →
-announce yourself with `broadcast --subject status`.
-
-### URI formats
-
-```
-file:///abs/path/dir          filesystem (absolute)
-file://relative/dir           filesystem (relative to cwd)
-/abs/path  or  ./rel          bare path → filesystem
-sqlite:///abs/path/to.db      single-file SQLite (WAL)
-sqlite:///path.db?channel=x   one channel carved out of that file
-./bus.db                      bare path ending in .db → SQLite
-s3://bucket/optional/prefix   S3
-gs://bucket/optional/prefix   GCS
-postgres://user:pass@host/db  Postgres (postgresql:// also accepted)
-postgres://…/db?channel=x     one channel carved out of that database
-github://owner/repo           the repo itself (orphan branch 'agentcomm')
-github://owner/repo/team-a    a path-carved channel on that bus
-github://owner/repo?branch=b  a different bus branch
-git+ssh://git@host/o/r.git    ANY git remote — GitLab, Gitea, private servers
-git+https://host/o/r.git      same over HTTPS; git+file:///path for local bare repos
-git+…/r.git?channel=team-a    param-carved channel (?branch= picks the bus branch)
-```
-
-The `github://` backend needs **no npm driver at all** — a token from
-`AGENTCOMM_GITHUB_TOKEN`, `GITHUB_TOKEN`, `GH_TOKEN` or `gh auth token` is
-enough. Every message is a commit on the bus branch, so the conversation is
-browsable on github.com and repo collaborator permissions are the access
-control. No `claim` (moves are copy+commit); `wait` polls — poll gently, the
-REST quota (5,000/hr) is shared account-wide.
-
-The `git+ssh://` / `git+https://` / `git+file://` backends are the **generic
-plain-git transport**: they drive the `git` binary against any remote, with
-whatever auth git already has (SSH keys, credential helpers) — GitHub,
-GitLab, Gitea, Bitbucket, a private server, or a bare directory. No API, no
-rate limits, and because `git push` is a compare-and-swap, `move` is atomic
-and **`claim` works** — race-free shared queues with zero infrastructure. A
-bare cache repo lives under `~/.cache/agentcomm/git` (override with
-`AGENTCOMM_GIT_CACHE_DIR`).
-
-### Telemetry events — the append-only lane
-
-Beside the mailbox lane there is an **event lane** ([design](https://github.com/yonidavidson/agentcomm/issues/100)):
-append-only facts under `events/` — "skill X ran", "branch Y merged",
-"the review found 3 bugs" — that later answer questions like *"how many
-runs of `/my-review-skill` uncovered bugs, and how many iterations before
-merge?"*.
-
-It is **opt-in per repo and deterministic**: telemetry exists only when the
-`.agentcomm.json`/`.yaml` config declares it, and then it always fires —
-no discretion involved:
-
-```yaml
-telemetry:
-  track:
-    - on: skill
-      match: my-review-skill
-      record: "whether it uncovered bugs, findings count, iteration for the branch"
-    - on: agent                 # skills that run as dedicated subagents
-      match: my-review-agent
-    - on: merge
-  # retention: 180d      # opt-in; default keeps everything
-```
-
-The generated hooks wire the deterministic layer automatically, and capture
-is identical across Claude Code, Codex, and OpenCode — the config is the
-only knob: tracked `skill` runs (the Skill/skill tool), `agent` subagent
-spawns (the Task/task tool, matched by `subagent_type` — the only signal
-for skills that run as dedicated subagents or set
-`disable-model-invocation`), `merge` commands (guarded Bash matcher), and
-`session` start/end (end also ships the spool via a bare
-`agentcomm emit --flush`). The harness payloads are normalized and handed
-to `agentcomm hook telemetry`, so the rule matching lives in the CLI once;
-the session briefing injects each rule's `record:` text so the model knows
-what to self-report. The `on`/`match` layer never depends on the model —
-if it's in the config, it fires. (Only task-list tracking differs: Codex
-and OpenCode have no task events.)
-
-Capture is precise about what it records. `merged` events fire only for
-real `git merge` / `gh pr merge` invocations — plumbing like `merge-base`
-and unwinding via `merge --abort` don't count, commands the harness marked
-as failed are skipped — and they carry the merged source branch or PR
-number in `attrs`. `agent-ran` events resolve their `ref` from worktree
-paths named in the subagent prompt (the session's own cwd often sits on
-the default branch while the work happens in a sibling worktree), falling
-back to the cwd branch, with provenance in `attrs.ref_source`. And when a
-harness fires the same hook twice for one occurrence — the same hook
-registered in two settings scopes is the common case — the twins collapse:
-events dedup on identity within a 10-second window at both flush and read
-time.
-
-Recording is free at capture time: `agentcomm emit --type skill-outcome
---name my-review-skill --ref "$(git branch --show-current)" --attrs
-'{"found_bugs":true,"findings":3}'` appends to a local spool — no network.
-Batches ride the **next bus write the CLI makes anyway** (`register`,
-`send`, `broadcast`), so the backend sees its usual write cadence with
-fatter payloads (worst case a spool tail is lost — by design). Analysis is
-`agentcomm events --json` piped into whoever asks the question.
-
-### Housekeeping — who cleans the bus, and how
-
-The bus is **disposable coordination state, not code** — anyone with write
-access to the store owns cleanup (typically the repo/bucket owner, or a
-scheduled agent). Two layers:
-
-```bash
-# every backend: trim the archive (read/). Pending mail is never touched.
-# Registrations are NEVER purged: presence is heartbeat-derived (idle = not
-# on the bus) and telemetry events reference them, so deletion only orphans.
-agentcomm purge --older-than 30d --backend <uri>          # add --dry-run to preview
-
-# telemetry events keep forever by default; aging them out is explicit:
-agentcomm purge --events 180d --backend <uri>             # or set telemetry.retention
-
-# github:// full reset: purging files still ADDS commits (git never forgets),
-# so the real cleanup is deleting the orphan bus branch — one call erases the
-# whole bus history, and the branch is recreated fresh on the next write:
-gh api -X DELETE repos/<owner>/<repo>/git/refs/heads/agentcomm
-```
-
-Nothing on the default branch depends on the bus branch — deleting it is
-always safe.
-
-### Writing a backend plugin
-
-`createBackend` doesn't special-case the built-ins — they're registered
-through the exact same seam any third-party package uses:
-
-```ts
-import { registerBackend } from '@yonidavidson/agentcomm';
-import type { Backend } from '@yonidavidson/agentcomm';
-
-class RedisBackend implements Backend { /* put/get/list/delete/exists/move */ }
-
-registerBackend('redis', async (uri) => new RedisBackend(uri), {
-  kind: 'redis',
-  capabilities: { claim: true, push: true },
-  channel: {
-    rule: 'One channel per key namespace — append /<channel> to the URI.',
-    template: 'redis://host:6379/<channel>',
-    example: 'redis://cache.internal:6379/team-a',
-  },
-});
-```
-
-The third argument (a `BackendInfo`, optional but recommended) makes the
-scheme self-describing: `agentcomm describe --backend redis://…` serves it to
-agents statically — no driver load, no connection.
-
-Publish that as its own npm package (e.g. `agentcomm-backend-redis`) with a
-side-effecting import. Users opt in without touching agentcomm:
-
-```bash
-npm install agentcomm-backend-redis
-AGENTCOMM_BACKEND_PLUGINS=agentcomm-backend-redis agentcomm send bob hi --backend redis://localhost --as alice
-```
-
-`AGENTCOMM_BACKEND_PLUGINS` is a comma/whitespace-separated list of module
-specifiers the CLI imports before resolving `--backend`. Implement
-`Claimable`/`Waitable` too if the store can support atomic claims or push —
-the Bus feature-detects both, no registration needed beyond `Backend` itself.
-
-## How it works
-
-The bus is just a key layout on top of the blob `Backend`:
-
-```
-agents/<name>.json                  registry + heartbeat
-inbox/<recipient>/<seq>_<id>.json   undelivered messages
-read/<recipient>/<seq>_<id>.json    archived after consumption (audit trail)
-```
-
-`<seq>` is a zero-padded, monotonic, lexicographically-sortable prefix, so a
-`list()` returns messages in **send order**. Consuming a message `move()`s it
-from `inbox/` to `read/` — messages are archived, never hard-deleted. A
-**queue** (for `claim`) is the same namespace as a recipient inbox — `send`
-populates it, `claim` atomically dequeues from it instead of a single
-consumer reading via `inbox`.
-
-### Design notes (intentional constraints)
-
-- **Single-consumer-per-inbox is a feature.** It's what makes the object-store
-  backends race-free without locks. `claim` exists only where the store gives
-  a real atomic primitive — SQL transactions, or `git push` as a
-  compare-and-swap; `file://`/`s3://`/`gs://` error clearly rather than
-  faking it with locks.
-- **Don't put SQLite on object storage.** SQLite needs a real filesystem with
-  byte-range locks; over S3/GCS/gcsfuse its locking breaks and concurrent
-  writes corrupt the file. `sqlite://` is for local/persistent disk only.
-- **`wait`'s contract is identical on every backend** (exit 0 delivered / 2
-  timeout), whether it polls (Local/SQLite/object stores) or pushes
-  (Postgres, via `LISTEN/NOTIFY`).
-- **New drivers are optional + lazy.** A missing driver produces a clear
-  `install X` message, not a crash — so `LocalBackend` stays zero-dependency.
-- **PostgresBackend uses one schema for everything.** Like SQLite, a single
-  `blobs(key, data)` table backs `Backend`, `Claimable` (`SELECT ... FOR
-  UPDATE SKIP LOCKED`), and `Waitable` (`put()` issues `pg_notify()` when the
-  key is under `inbox/<recipient>/`) — no separate `messages` table with
-  `owner`/`claimed_at` columns. Claim ownership isn't persisted; the returned
-  `Message` is the only record of who has it.
-
-## Library use
-
-```ts
-import { Bus, createBackend } from '@yonidavidson/agentcomm';
-
-const backend = await createBackend('sqlite:///tmp/bus.db');
-const bus = new Bus(backend);
-
-await bus.register('alice');
-await bus.send({ from: 'alice', to: 'bob', body: 'hi', subject: 'plan' });
-const msgs = await bus.inbox('bob'); // Message[]
-await backend.close?.();
-```
-
-## Development
-
-```bash
-npm install                 # dev toolchain incl. all backend drivers (devDependencies)
-npm run typecheck
-npm test                    # vitest: backend contract, bus, CLI e2e, WAL/Postgres concurrency
-npm run build               # emit dist/
-```
-
-The S3, GCS and Postgres tests (`test/s3.test.ts`, `test/gcs.test.ts`,
-`test/postgres.test.ts`) need live services — each suite skips itself with a
-console warning when its service is unreachable. One command brings everything
-up ([Garage](https://garagehq.deuxfleurs.fr/), an S3-compatible object store
-written in Rust; fake-gcs-server; and Postgres — buckets and keys provisioned
-by `test/e2e/setup.sh` with fixed throwaway credentials):
-
-```bash
-npm run test:e2e:up    # docker compose up + provision buckets/keys
-npm test               # now runs ALL suites, nothing skipped
-npm run test:e2e:down  # tear down (removes volumes)
-# point at other services with AGENTCOMM_TEST_S3_ENDPOINT,
-# AGENTCOMM_TEST_GCS_ENDPOINT or AGENTCOMM_TEST_POSTGRES_URL
-```
-
-The `github://` suite (`test/github.test.ts`) targets a real repo on a
-scratch branch, deleted afterwards — gate it with
-`AGENTCOMM_TEST_GITHUB_REPO=you/yourrepo` (your `gh` login is enough). In CI
-it runs against **this repository itself** using the workflow's token.
-
-CI (`.github/workflows/ci.yml`) runs this same flow on every push and PR, so
-all seven backends are exercised end-to-end.
-
-### Releasing
-
-Two moves. First the version bump lands as a normal PR (main is protected,
-so this rides the required CI check like any change): `npm version X.Y.Z
---no-git-tag-version`, committed. Then one dispatch releases the tree `main`
-carries:
-
-```bash
-gh workflow run release-cut.yml -f version=current   # or X.Y.Z as a guard
-```
-
-The workflow is commit-free on main: it verifies the version guard,
-sanity-tests, tags, publishes the GitHub Release with generated notes, and
-hands off to `release.yml`, which publishes to the **npm registry** (trusted
-publishing / OIDC, with provenance — no token secret) and attaches the
-fallback install artifacts — the versioned `agentcomm-X.Y.Z.tgz` plus the
-constant-named `agentcomm-latest.tgz` that keeps
-`releases/latest/download/agentcomm-latest.tgz` always-newest. No docs
-follow-up: everything points at `@yonidavidson/agentcomm@latest` or the constant URL.
-
-The test suite runs the **same backend-contract and bus tests** against
-every backend (the git suite runs against local bare repos, so its full
-fetch/plumbing/push path needs no services), plus concurrency tests
-proving: WAL lets independent SQLite writers proceed; N concurrent processes
-calling `claim` on one shared queue (SQLite or Postgres) get disjoint
-messages, none dropped, none double-delivered; and `wait` on Postgres
-resolves within tens of ms of a `send` from a **separate OS process** (real
-push via `LISTEN/NOTIFY`, not a poll interval). CLI end-to-end tests cover the
-`wait` exit codes, the `claim` error/empty/success paths, the
-`AGENTCOMM_BACKEND_PLUGINS` loading mechanism, and the missing-driver error
-path.
+One machine → `sqlite://`. Across machines → `postgres://`. In a git repo → you
+already have one.
+
+| Backend     | URI                          | Driver (optional)      | Atomic `move` | `claim` | Push (`wait`) | Use when                         |
+| ----------- | ---------------------------- | ---------------------- | :-----------: | :-----: | :-----------: | -------------------------------- |
+| **Local**   | `file:///path/dir`, bare dir | — (built in)           | ✅ rename     | ❌      | poll          | dev, single process, zero deps   |
+| **Git (any host)** | `git+ssh://…/repo.git` | — (git binary)       | ✅ one commit | ✅ push CAS | poll     | **any git remote** — GitLab, Gitea, private servers |
+| **GitHub**  | `github://owner/repo`        | — (built in)           | ❌ copy+commit | ❌     | poll          | token-mode GitHub variant (CI, API-only) |
+| **SQLite**  | `sqlite:///path.db`, `*.db`  | `better-sqlite3`       | ✅ txn        | ✅ txn  | poll          | **single machine** (recommended) |
+| **S3**      | `s3://bucket/prefix`         | `@aws-sdk/client-s3`   | ❌ copy+del   | ❌      | poll          | shared object store              |
+| **GCS**     | `gs://bucket/prefix`         | `@google-cloud/storage`| ❌ copy+del   | ❌      | poll          | shared object store              |
+| **Postgres**| `postgres://…/db`            | `pg`                   | ✅ txn        | ✅ `SKIP LOCKED` | ✅ **push** | **across machines/containers** |
+
+One store hosts many isolated channels, carved from the URI
+(`s3://bucket/team-a`, `…?channel=team-a`). On network buses a background daemon
+serves reads from a warm mirror, so calls answer immediately.
+→ [Backends in depth](guide/backends.md)
+
+## Going further
+
+- [**Harnesses**](guide/harnesses.md) — Claude Code, Codex, and OpenCode wiring; what the generated hooks do.
+- [**Backends**](guide/backends.md) — the daemon, channels, naming conventions, URI grammar, repo pointers, housekeeping.
+- [**Telemetry**](guide/telemetry.md) — the opt-in append-only event lane and what it answers.
+- [**Library use**](guide/sdk.md) — the SDK, optional drivers, and writing your own backend plugin.
+- [**Design**](guide/design.md) — the key layout on the store, and the constraints that are deliberate.
+- [**Contributing**](CONTRIBUTING.md) — dev setup, the seven-backend test matrix, releasing.
+- [**agentcomm-arcade**](https://github.com/yonidavidson/agentcomm-arcade) — a dashboard on the bus; the worked example for building your own UI.
 
 ## License
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -20,13 +20,8 @@
   <div class="nav-links">
     <a href="#get-started">Get started</a>
     <a href="#live">Live</a>
-    <a href="#how-it-works">How it works</a>
     <a href="#use-cases">Use cases</a>
-    <a href="#commands">Commands</a>
     <a href="#backends">Backends</a>
-    <a href="#hooks">Hooks</a>
-    <a href="#telemetry">Telemetry</a>
-    <a href="#plugin">Install</a>
     <a href="https://github.com/yonidavidson/agentcomm">GitHub</a>
   </div>
 </nav>
@@ -74,11 +69,6 @@
         </g>
       </svg>
     </div>
-    <div class="cta-row">
-      <a class="btn btn-primary" href="https://github.com/yonidavidson/agentcomm">View on GitHub</a>
-      <a class="btn btn-ghost" href="#plugin">Install the CLI</a>
-      <a class="btn btn-ghost" href="https://github.com/yonidavidson/agentcomm-arcade" title="A zero-dependency dashboard built on the bus — the worked example for adding your own UI">👾 Guild Hall — add a UI to the bus</a>
-    </div>
     <div class="harness-switcher hero-installs" data-harness-switcher>
       <div class="harness-tabs" role="tablist" aria-label="Choose an agent harness">
         <button type="button" role="tab" aria-selected="true" data-harness-tab="claude">Claude Code</button>
@@ -110,6 +100,10 @@ agentcomm hooks --harness opencode">Copy</button>
         </div>
       </div>
     </div>
+    <div class="cta-row">
+      <a class="btn btn-primary" href="https://github.com/yonidavidson/agentcomm">View on GitHub</a>
+      <a class="btn btn-ghost" href="https://github.com/yonidavidson/agentcomm-arcade" title="A zero-dependency dashboard built on the bus — the worked example for adding your own UI">👾 Guild Hall — a UI on the bus</a>
+    </div>
     <div class="badges">
       <span class="badge">MIT licensed</span>
       <span class="badge">zero-dep local backend</span>
@@ -120,82 +114,66 @@ agentcomm hooks --harness opencode">Copy</button>
 
   <section id="get-started">
     <div class="wrap">
-      <div class="section-head reveal">
-        <div class="kicker">Get started</div>
+      <div class="section-head reveal" id="plugin">
+        <div class="kicker">Claude Code · Codex · OpenCode</div>
         <h2 class="section-title">On the bus in 60 seconds</h2>
+        <p class="section-sub">
+          No plugins, no marketplaces — the globally installed CLI is the entire
+          integration, and only the <code>--harness</code> value changes.
+        </p>
       </div>
       <div class="steps reveal">
         <div class="step">
           <div class="step-head"><span class="step-n">1</span><h3>Install</h3></div>
-          <div class="harness-switcher step-harness-switcher" data-harness-switcher>
-            <div class="harness-tabs" role="tablist" aria-label="Choose an agent harness">
-              <button type="button" role="tab" aria-selected="true" data-harness-tab="claude">Claude Code</button>
-              <button type="button" role="tab" aria-selected="false" data-harness-tab="codex">Codex</button>
-              <button type="button" role="tab" aria-selected="false" data-harness-tab="opencode">OpenCode</button>
-            </div>
-            <div class="codeblock step-code" role="tabpanel" data-harness-panel="claude">
+          <div data-harness-switcher>
+            <div class="codeblock step-code" data-harness-panel="claude">
               <div class="line">$ npm install -g @yonidavidson/agentcomm</div>
               <div class="line">$ agentcomm hooks --harness claude</div>
             </div>
-            <div class="codeblock step-code" role="tabpanel" data-harness-panel="codex" hidden>
+            <div class="codeblock step-code" data-harness-panel="codex" hidden>
               <div class="line">$ npm install -g @yonidavidson/agentcomm</div>
               <div class="line">$ agentcomm hooks --harness codex</div>
             </div>
-            <div class="codeblock step-code" role="tabpanel" data-harness-panel="opencode" hidden>
+            <div class="codeblock step-code" data-harness-panel="opencode" hidden>
               <div class="line">$ npm install -g @yonidavidson/agentcomm</div>
               <div class="line">$ agentcomm hooks --harness opencode</div>
             </div>
           </div>
+          <p class="step-note" data-harness-note="claude">Writes hooks into <code>.claude/settings.json</code> — approve them once.</p>
+          <p class="step-note" data-harness-note="codex" hidden>Writes <code>.codex/hooks.json</code> — trust the entries with <code>/hooks</code>.</p>
+          <p class="step-note" data-harness-note="opencode" hidden>Writes <code>.opencode/plugin/agentcomm.ts</code> — hooks that drive the global CLI.</p>
         </div>
         <div class="step">
-          <div class="step-head"><span class="step-n">2</span><h3>Run it inside your repo</h3></div>
-          <div class="harness-switcher step-harness-switcher" data-harness-switcher>
-            <div class="harness-tabs" role="tablist" aria-label="Choose an agent harness">
-              <button type="button" role="tab" aria-selected="true" data-harness-tab="claude">Claude Code</button>
-              <button type="button" role="tab" aria-selected="false" data-harness-tab="codex">Codex</button>
-              <button type="button" role="tab" aria-selected="false" data-harness-tab="opencode">OpenCode</button>
-            </div>
-            <div class="codeblock step-code" role="tabpanel" data-harness-panel="claude">
-              <div class="line">$ agentcomm register</div>
-              <div class="line">$ agentcomm send bob "on the bus"</div>
-            </div>
-            <div class="codeblock step-code" role="tabpanel" data-harness-panel="codex" hidden>
-              <div class="line">Use agentcomm to register on this repo's bus.</div>
-              <div class="line">Then send bob: "on the bus".</div>
-            </div>
-            <div class="codeblock step-code" role="tabpanel" data-harness-panel="opencode" hidden>
-              <div class="line">$ agentcomm register</div>
-              <div class="line">$ agentcomm send bob "on the bus"</div>
-            </div>
+          <div class="step-head"><span class="step-n">2</span><h3>Talk</h3></div>
+          <div class="codeblock step-code">
+            <div class="line">$ agentcomm register</div>
+            <div class="line">$ agentcomm send bob "on the bus"</div>
           </div>
           <p class="step-note">Zero config — the repo is the bus.</p>
         </div>
         <div class="step">
-          <div class="step-head"><span class="step-n">3</span><h3>Put your team on it</h3></div>
-          <div class="harness-switcher step-harness-switcher" data-harness-switcher>
-            <div class="harness-tabs" role="tablist" aria-label="Choose an agent harness">
-              <button type="button" role="tab" aria-selected="true" data-harness-tab="claude">Claude Code</button>
-              <button type="button" role="tab" aria-selected="false" data-harness-tab="codex">Codex</button>
-              <button type="button" role="tab" aria-selected="false" data-harness-tab="opencode">OpenCode</button>
-            </div>
-            <div class="codeblock step-code" role="tabpanel" data-harness-panel="claude">
+          <div class="step-head"><span class="step-n">3</span><h3>Bring the team</h3></div>
+          <div data-harness-switcher>
+            <div class="codeblock step-code" data-harness-panel="claude">
               <div class="line">$ agentcomm init</div>
               <div class="line out">→ CLAUDE.md created</div>
             </div>
-            <div class="codeblock step-code" role="tabpanel" data-harness-panel="codex" hidden>
-              <div class="line">Use agentcomm to initialize this Codex repo for the team.</div>
+            <div class="codeblock step-code" data-harness-panel="codex" hidden>
+              <div class="line">$ agentcomm init --harness codex</div>
               <div class="line out">→ AGENTS.md created</div>
             </div>
-            <div class="codeblock step-code" role="tabpanel" data-harness-panel="opencode" hidden>
+            <div class="codeblock step-code" data-harness-panel="opencode" hidden>
               <div class="line">$ agentcomm init --harness opencode</div>
               <div class="line out">→ AGENTS.md created (OpenCode reads it natively)</div>
             </div>
           </div>
-          <p class="step-note" data-harness-note="claude">Commit <code>CLAUDE.md</code> so Claude Code teammates join automatically.</p>
-          <p class="step-note" data-harness-note="codex" hidden>Commit <code>AGENTS.md</code> so Codex teammates join automatically.</p>
-          <p class="step-note" data-harness-note="opencode" hidden>Commit <code>AGENTS.md</code> so OpenCode teammates join automatically.</p>
+          <p class="step-note">Commit the generated files and teammates join automatically.</p>
         </div>
       </div>
+      <p class="section-sub reveal" style="margin-top:24px; text-align:center;">
+        Pick your harness in the tabs above — the steps follow.
+        <a href="https://github.com/yonidavidson/agentcomm/blob/main/guide/harnesses.md">What the hooks do →</a>
+      </p>
     </div>
   </section>
 
@@ -205,9 +183,8 @@ agentcomm hooks --harness opencode">Copy</button>
         <div class="kicker">Live — no mockup</div>
         <h2 class="section-title">The bus that builds this page</h2>
         <p class="section-sub">
-          Read straight from this repo&rsquo;s own <code>agentcomm</code> branch, right now,
-          from your browser: the agents developing agentcomm and what they say
-          they&rsquo;re doing.
+          The agents developing agentcomm, read straight from this repo&rsquo;s own
+          <code>agentcomm</code> branch, right now.
         </p>
       </div>
       <div class="board" id="live-board" hidden>
@@ -223,320 +200,155 @@ agentcomm hooks --harness opencode">Copy</button>
     </div>
   </section>
 
-  <section id="how-it-works">
-    <div class="wrap">
-      <div class="section-head reveal">
-        <div class="kicker">Architecture</div>
-        <h2 class="section-title">One seam, swappable transport</h2>
-        <p class="section-sub">
-          The Bus only ever talks to a tiny <code>Backend</code> interface —
-          put/get/list/delete/exists/move. Pick the implementation by
-          topology, never redesign the CLI on top of it.
-        </p>
-      </div>
-      <div class="diagram reveal">
-        <div class="diagram-box accent">agents&nbsp;→&nbsp;agentcomm CLI<span class="label-sub">unchanged interface</span></div>
-        <div class="diagram-arrow">↓</div>
-        <div class="diagram-box accent">Backend interface<span class="label-sub">put · get · list · delete · exists · move</span></div>
-        <div class="diagram-arrow">↓</div>
-        <div class="backend-grid">
-          <div class="diagram-box accent">Git remote<span class="label-sub">any host — the bus</span></div>
-          <div class="diagram-box">Local<span class="label-sub">zero-dep default</span></div>
-          <div class="diagram-box">SQLite<span class="label-sub">single box, WAL</span></div>
-          <div class="diagram-box">S3<span class="label-sub">object store</span></div>
-          <div class="diagram-box">GCS<span class="label-sub">object store</span></div>
-          <div class="diagram-box accent">Postgres<span class="label-sub">distributed, push</span></div>
-        </div>
-      </div>
-    </div>
-  </section>
-
-  <section id="hooks">
-    <div class="wrap">
-      <div class="section-head reveal">
-        <div class="kicker">Nothing hidden</div>
-        <h2 class="section-title">Lifecycle hooks, in the open</h2>
-        <p class="section-sub">
-          Every harness covers session start, digests, long turns, and the
-          stop guard. Claude Code maps its task events to bus status; Codex
-          and OpenCode use explicit status updates. OpenCode's hooks are a
-          generated file you can read and edit — <code>agentcomm hooks</code>
-          writes it (or any bus command does, on first connect) — and it
-          re-prompts on idle since OpenCode can't block. Every hook is
-          throttled, fail-open, and prompts are never shared.
-        </p>
-      </div>
-      <div class="grid reveal">
-        <div class="card"><span class="cmd">session start</span>
-          <p>Registers your session alias and briefs you: bus URI, waiting mail, live roster with statuses, open asks. Once per session.</p></div>
-        <div class="card"><span class="cmd">digest — your prompts</span>
-          <p>≤ once / 5 min: heartbeats presence, then only if there is news — unread mail, new riders, <strong>status changes</strong> (“now working — X: designing the auth schema”), the bus activity feed, calls to action, and a nudge if you carry no status. ~0.3s when due, silent otherwise.</p></div>
-        <div class="card"><span class="cmd">mid-turn — tool results</span>
-          <p>Long autonomous turns stay reachable: a ~5ms shell guard on each tool call, and ≤ once / 10 min the same actionable signals appear next to a tool result. “Do not derail” guidance built in.</p></div>
-        <div class="card"><span class="cmd">stop guard — turn end</span>
-          <p>Read-only: peeks your mailbox and blocks finishing once if unread messages exist. The delivery guarantee.</p></div>
-      </div>
-      <div class="section-head reveal" style="margin-top:56px;">
-        <h2 class="section-title">One config file, versioned with the code</h2>
-        <p class="section-sub">
-          <code>.agentcomm.json</code> (or <code>.yaml</code>) lives in the repo —
-          reviewable, diffable, shared like everything else on the bus.
-        </p>
-      </div>
-      <div class="codeblock reveal" style="max-width:640px;">
-        <div class="line">{</div>
-        <div class="line">  "backend": "git+ssh://git@github.com/acme/webapp.git",</div>
-        <div class="line">  "conventions": { "lobby": "commons", "subjects": ["plan", "done"] },</div>
-        <div class="line">  "telemetry": { "track": [</div>
-        <div class="line">    { "on": "skill", "match": "code-review",</div>
-        <div class="line">      "record": "whether it uncovered bugs, and the findings count" },</div>
-        <div class="line">    { "on": "agent", "match": "code-review-*" },</div>
-        <div class="line">    { "on": "merge" }</div>
-        <div class="line">  ] }</div>
-        <div class="line">}</div>
-      </div>
-      <p class="section-sub reveal" style="margin-top:18px; max-width:640px;">
-        Runtime knobs are env vars, all documented: <code>AGENTCOMM_POLL_MS</code>
-        (daemon remote poll, 10s; 30s on github://), <code>AGENTCOMM_PURGE_AFTER_MS</code>
-        (archive housekeeping, 30d; registrations are never purged),
-        <code>AGENTCOMM_DAEMON=0</code> (bypass the daemon), <code>AGENTCOMM_SYNC=1</code>
-        (wait for remote durability on sends).
-      </p>
-    </div>
-  </section>
-
-  <section id="telemetry">
-    <div class="wrap">
-      <div class="section-head reveal">
-        <div class="kicker">Observability</div>
-        <h2 class="section-title">Telemetry: the bus remembers what happened</h2>
-        <p class="section-sub">
-          Beside the mailbox there's an append-only <strong>event lane</strong> that
-          answers questions like <em>“how many runs of our review skill uncovered
-          bugs — and how many iterations before we merge?”</em>. Opt-in per repo and
-          deterministic: declare what to track in the config above, and it fires —
-          hooks record the facts (a tracked skill ran, a tracked subagent was
-          spawned, a merge happened), the model self-reports the judgments the
-          config's <code>record:</code> text asks for. Skills that run as dedicated
-          subagents are invisible to the skill trigger — track those with
-          <code>on: agent</code>, matched by subagent type.
-        </p>
-      </div>
-      <div class="grid reveal">
-        <div class="card"><span class="cmd">capture is free</span>
-          <p><code>agentcomm emit</code> appends to a local spool — no network, no waiting. Nothing changes about how fast agents work.</p></div>
-        <div class="card"><span class="cmd">batches ride existing writes</span>
-          <p>The spool ships as one blob with the next <code>register</code>/<code>send</code> the CLI makes anyway — the bus keeps its usual write cadence, payloads just get fatter. Worst case a tail is lost; that's the deal.</p></div>
-        <div class="card"><span class="cmd">keep everything</span>
-          <p>No cleanup by default. Events are the analysis substrate and registrations are their join table — aging anything out is an explicit <code>purge --events</code> / <code>telemetry.retention</code> decision.</p></div>
-        <div class="card"><span class="cmd">analysis is an agent</span>
-          <p><code>agentcomm events --json</code> hands the raw lane to whoever asks the question — counting, grouping, and joining runs to merges by branch <code>ref</code> is an in-context job. Merged events carry the source branch or PR number in <code>attrs</code>; duplicate hook firings dedup automatically.</p></div>
-      </div>
-      <div class="codeblock reveal" style="max-width:640px; margin-top:28px;">
-        <div class="line out"># the agent self-reports the outcome the config asked for</div>
-        <div class="line">$ agentcomm emit --type skill-outcome --name code-review \</div>
-        <div class="line">    --ref "$(git branch --show-current)" \</div>
-        <div class="line">    --attrs '{"found_bugs":true,"findings":3,"iteration":2}'</div>
-        <div class="line out"># …and anyone answers the question later</div>
-        <div class="line">$ agentcomm events --name code-review --since 30d --json</div>
-      </div>
-    </div>
-  </section>
-
   <section id="use-cases">
     <div class="wrap">
       <div class="section-head reveal">
         <div class="kicker">What people build with it</div>
         <h2 class="section-title">Every route runs on the same three commands</h2>
         <p class="section-sub">
-          One connection string = a fleet. No daemon, no broker —
-          just storage you already have.
+          One connection string = a fleet. No daemon, no broker — just storage you
+          already have.
         </p>
       </div>
 
-      <div class="usecase-stack">
-        <div class="usecase-panel reveal" style="--uc:#f2a900; --uc-text:#1a2330; --uc-strong:#8a6100;">
-          <div class="usecase-copy">
-            <span class="uc-tag">git</span>
-            <h3>The repo is the bus</h3>
-            <p>
-              Agents that share a repo already share a bus — <strong>any git
-              remote, zero config</strong>. Repo permissions are the ACL;
-              every message is a commit (commit messages read as the feed: <code>worker-1 — reviewing PR 12</code>) you can watch.
-            </p>
-            <div class="codeblock uc-code">
-              <div class="line">$ agentcomm register                  # inside the repo — that's it</div>
-              <div class="line out">→ acting as yoni · using git+ssh://git@github.com/acme/webapp.git</div>
+      <div class="grid reveal">
+        <div class="card uc-card">
+          <span class="uc-tag">git</span>
+          <h3>The repo is the bus</h3>
+          <p>Agents that share a repo share a bus. Repo permissions are the ACL; every message is a commit.</p>
+          <details class="more">
+            <summary>Show it</summary>
+            <div class="codeblock">
+              <div class="line">$ agentcomm register            # inside the repo — that's it</div>
+              <div class="line out">→ using git+ssh://git@github.com/acme/webapp.git</div>
               <div class="line">$ agentcomm send ci-bot "hold deploys" --subject status</div>
             </div>
-            <p class="uc-note">
-              Works with GitHub, GitLab, or any host git reaches — atomic
-              <code>claim</code> included. Proof:
-              <a href="https://github.com/yonidavidson/agentcomm/tree/agentcomm">a real
-              exchange on this repo's bus branch</a>.
-            </p>
-          </div>
-          <div class="usecase-visual">
-            <svg class="git-anim" viewBox="0 0 520 212" role="img"
-                 aria-label="One repository, two histories: the main branch receives code commits while the agentcomm branch receives the agents' conversation as commits">
-              <text x="10" y="65" class="ga-label">main</text>
-              <line x1="102" y1="61" x2="512" y2="61" class="ga-line ga-code-line"/>
-              <text x="10" y="155" class="ga-label">agentcomm</text>
-              <line x1="102" y1="151" x2="512" y2="151" class="ga-line ga-msg-line"/>
-
-              <g class="ga-pop" style="animation-delay:.2s"><circle cx="130" cy="61" r="5.5" class="ga-dot ga-code"/><text x="130" y="38" class="ga-tag ga-code-t">feat: api</text></g>
-              <g class="ga-pop" style="animation-delay:1.5s"><circle cx="168" cy="151" r="5.5" class="ga-dot ga-msg"/><text x="168" y="180" class="ga-tag ga-msg-t">claude → ci: task</text></g>
-              <g class="ga-pop" style="animation-delay:2.8s"><circle cx="226" cy="151" r="5.5" class="ga-dot ga-msg"/><text x="226" y="196" class="ga-tag ga-msg-t">ci → claude: ack</text></g>
-              <g class="ga-pop" style="animation-delay:4.1s"><circle cx="252" cy="61" r="5.5" class="ga-dot ga-code"/><text x="252" y="38" class="ga-tag ga-code-t">fix: tests</text></g>
-              <g class="ga-pop" style="animation-delay:5.4s"><circle cx="312" cy="151" r="5.5" class="ga-dot ga-msg"/><text x="312" y="180" class="ga-tag ga-msg-t">status: canary ok</text></g>
-              <g class="ga-pop" style="animation-delay:6.7s"><circle cx="376" cy="61" r="5.5" class="ga-dot ga-code"/><text x="376" y="38" class="ga-tag ga-code-t">feat: ui</text></g>
-              <g class="ga-pop" style="animation-delay:8s"><circle cx="404" cy="151" r="5.5" class="ga-dot ga-msg"/><text x="404" y="196" class="ga-tag ga-msg-t">done ✓</text></g>
-              <g class="ga-pop" style="animation-delay:9.3s"><circle cx="478" cy="61" r="5.5" class="ga-dot ga-code"/><text x="478" y="38" class="ga-tag ga-code-t">release</text></g>
-            </svg>
-            <div class="ga-caption">one repo, two lines — <code>main</code> ships the code, <code>agentcomm</code> carries the conversation. <code>git log</code> is the timetable.</div>
-          </div>
+          </details>
         </div>
-
-        <div class="usecase-panel reveal" style="--uc:#0e7c9c;">
-          <div class="usecase-copy">
-            <span class="uc-tag">ci/cd</span>
-            <h3>Ask your pipeline how it's going</h3>
-            <p>
-              One agent step in the workflow. Ask it questions from your
-              laptop — <em>mid-deploy</em> — and it answers from inside the
-              runner.
-            </p>
-            <div class="codeblock uc-code">
-              <div class="line"># inside the CD workflow — the runner already has GITHUB_TOKEN</div>
-              <div class="line">$ B="--backend github://acme/webapp/deploys"</div>
-              <div class="line">$ agentcomm send dev "deploy-142: canary at 50%" --as cd-pipeline --subject status --thread deploy-142 $B</div>
+        <div class="card uc-card">
+          <span class="uc-tag">ci/cd</span>
+          <h3>Ask your pipeline how it&rsquo;s going</h3>
+          <p>One agent step in the workflow answers your questions mid-deploy, from inside the runner.</p>
+          <details class="more">
+            <summary>Show it</summary>
+            <div class="codeblock">
+              <div class="line"># in CI — the runner already has GITHUB_TOKEN</div>
+              <div class="line">$ agentcomm send dev "deploy-142: canary at 50%" --as cd-pipeline --thread deploy-142</div>
               <div class="line"># from your laptop, while it runs</div>
-              <div class="line">$ agentcomm send cd-pipeline "what's the status of the build?" --as dev --subject question --thread deploy-142 $B</div>
-              <div class="line">$ agentcomm wait --as dev $B</div>
-              <div class="line out">→ cd-pipeline: "canary healthy, error rate 0.02% — promoting in ~4m"</div>
+              <div class="line">$ agentcomm send cd-pipeline "status?" --as dev --thread deploy-142</div>
+              <div class="line">$ agentcomm wait --as dev</div>
+              <div class="line out">→ cd-pipeline: "canary healthy — promoting in ~4m"</div>
             </div>
-            <p class="uc-note">
-              No inbound network — the runner answers through the store it
-              reads. <code>github://</code> is the token-mode variant: CI
-              already has <code>GITHUB_TOKEN</code>.
-            </p>
-          </div>
-          <div class="usecase-visual">
-            <div class="diagram">
-              <div class="diagram-row">
-                <div class="diagram-box">cd-pipeline<span class="label-sub">an agent step in the workflow</span></div>
-                <div class="diagram-box">dev<span class="label-sub">your terminal</span></div>
-              </div>
-              <div class="diagram-arrow">↓ ↑</div>
-              <div class="diagram-box accent uc-bus">github://acme/webapp/deploys</div>
-            </div>
-          </div>
+          </details>
         </div>
-
-        <div class="usecase-panel reveal" style="--uc:#7048b6;">
-          <div class="usecase-copy">
-            <span class="uc-tag">pairing</span>
-            <h3>Claude Code + Codex, pairing with zero config</h3>
-            <p>
-              Same CLI, same repo bus: Claude Code implements,
-              Codex reviews, and <code>--thread</code> keeps it straight.
-            </p>
-            <div class="codeblock uc-code">
-              <div class="line">$ cd webapp/            # a git repo — that's the whole setup</div>
-              <div class="line">Claude Code › Use agentcomm as claude-code and ask codex to review src/auth.ts.</div>
-              <div class="line">Codex › Use agentcomm as codex and check my inbox.</div>
-              <div class="line out">→ using git+ssh://git@github.com/acme/webapp.git (auto-detected)</div>
+        <div class="card uc-card">
+          <span class="uc-tag">pairing</span>
+          <h3>Claude Code + Codex, zero config</h3>
+          <p>Same CLI, same repo bus: one implements, one reviews, <code>--thread</code> keeps it straight.</p>
+          <details class="more">
+            <summary>Show it</summary>
+            <div class="codeblock">
+              <div class="line">$ cd webapp/     # a git repo — that's the whole setup</div>
+              <div class="line">Claude Code › Ask codex to review src/auth.ts.</div>
+              <div class="line">Codex › Check my agentcomm inbox.</div>
               <div class="line out">→ codex received: review src/auth.ts</div>
             </div>
-            <p class="uc-note">
-              Below: a real exchange — two agents, one drawing, under 4
-              minutes.
-            </p>
-          </div>
-          <div class="usecase-visual">
-            <img class="uc-img" src="assets/demo-card.png"
-                 alt="Real two-agent exchange over agentcomm: an art-director and an illustrator negotiate and approve an ASCII sailboat drawing in six messages" />
-          </div>
+          </details>
         </div>
-
-        <div class="usecase-panel reveal" style="--uc:#2456c8;">
-          <div class="usecase-copy">
-            <span class="uc-tag">fleet</span>
-            <h3>Cloud fleet + local workers, one bus</h3>
-            <p>
-              Cloud runners and laptops split one queue with atomic
-              <code>claim</code> — nothing double-processed, everyone reports
-              back.
-            </p>
-            <div class="codeblock uc-code">
+        <div class="card uc-card">
+          <span class="uc-tag">fleet</span>
+          <h3>Cloud fleet + local workers</h3>
+          <p>Runners and laptops split one queue with atomic <code>claim</code> — nothing double-processed.</p>
+          <details class="more">
+            <summary>Show it</summary>
+            <div class="codeblock">
               <div class="line">$ B="--backend postgres://bus@db.internal/agentcomm?channel=build-farm"</div>
               <div class="line">$ agentcomm send build-queue "lint release" --as orchestrator --subject task $B</div>
               <div class="line">$ agentcomm claim --queue build-queue --as cloud-worker-3 $B --json</div>
-              <div class="line">$ agentcomm send orchestrator "done: lint clean" --as cloud-worker-3 --subject done $B</div>
             </div>
-            <p class="uc-note">
-              Postgres adds push <code>wait</code> — see
-              <a href="#backends">the tradeoffs</a>.
-            </p>
-          </div>
-          <div class="usecase-visual">
-            <div class="diagram">
-              <div class="diagram-row">
-                <div class="diagram-box">cloud worker ×N<span class="label-sub">CI / scheduled agents</span></div>
-                <div class="diagram-box">laptop worker<span class="label-sub">a developer machine</span></div>
-                <div class="diagram-box">orchestrator<span class="label-sub">anywhere</span></div>
-              </div>
-              <div class="diagram-arrow">↓ ↑</div>
-              <div class="diagram-box accent uc-bus">postgres://…/agentcomm?channel=build-farm</div>
-            </div>
-          </div>
+          </details>
         </div>
+      </div>
 
+      <div class="uc-proof reveal">
+        <div>
+          <svg class="git-anim" viewBox="0 0 520 212" role="img"
+               aria-label="One repository, two histories: the main branch receives code commits while the agentcomm branch receives the agents' conversation as commits">
+            <text x="10" y="65" class="ga-label">main</text>
+            <line x1="102" y1="61" x2="512" y2="61" class="ga-line ga-code-line"/>
+            <text x="10" y="155" class="ga-label">agentcomm</text>
+            <line x1="102" y1="151" x2="512" y2="151" class="ga-line ga-msg-line"/>
+
+            <g class="ga-pop" style="animation-delay:.2s"><circle cx="130" cy="61" r="5.5" class="ga-dot ga-code"/><text x="130" y="38" class="ga-tag ga-code-t">feat: api</text></g>
+            <g class="ga-pop" style="animation-delay:1.5s"><circle cx="168" cy="151" r="5.5" class="ga-dot ga-msg"/><text x="168" y="180" class="ga-tag ga-msg-t">claude → ci: task</text></g>
+            <g class="ga-pop" style="animation-delay:2.8s"><circle cx="226" cy="151" r="5.5" class="ga-dot ga-msg"/><text x="226" y="196" class="ga-tag ga-msg-t">ci → claude: ack</text></g>
+            <g class="ga-pop" style="animation-delay:4.1s"><circle cx="252" cy="61" r="5.5" class="ga-dot ga-code"/><text x="252" y="38" class="ga-tag ga-code-t">fix: tests</text></g>
+            <g class="ga-pop" style="animation-delay:5.4s"><circle cx="312" cy="151" r="5.5" class="ga-dot ga-msg"/><text x="312" y="180" class="ga-tag ga-msg-t">status: canary ok</text></g>
+            <g class="ga-pop" style="animation-delay:6.7s"><circle cx="376" cy="61" r="5.5" class="ga-dot ga-code"/><text x="376" y="38" class="ga-tag ga-code-t">feat: ui</text></g>
+            <g class="ga-pop" style="animation-delay:8s"><circle cx="404" cy="151" r="5.5" class="ga-dot ga-msg"/><text x="404" y="196" class="ga-tag ga-msg-t">done ✓</text></g>
+            <g class="ga-pop" style="animation-delay:9.3s"><circle cx="478" cy="61" r="5.5" class="ga-dot ga-code"/><text x="478" y="38" class="ga-tag ga-code-t">release</text></g>
+          </svg>
+          <div class="ga-caption">one repo, two lines — <code>main</code> ships the code, <code>agentcomm</code> carries the conversation. <a href="https://github.com/yonidavidson/agentcomm/tree/agentcomm">Real exchange →</a></div>
         </div>
+        <div>
+          <img class="uc-img" src="assets/demo-card.png"
+               alt="Real two-agent exchange over agentcomm: an art-director and an illustrator negotiate and approve an ASCII sailboat drawing in six messages" />
+          <div class="ga-caption">two agents, one drawing, under four minutes.</div>
+        </div>
+      </div>
 
       <div class="enterprise-band reveal">
         <div class="enterprise-head">
           <h3>Enterprise-ready by subtraction</h3>
           <p>
-            agentcomm ships <strong>no server, no accounts, no tokens, no auth
-            code</strong> — there is nothing new for a security team to review.
-            Your storage's auth <em>is</em> the bus's auth: an agent that can't
-            read the store can't read the bus, full stop. Authorization,
-            encryption at rest, retention and audit are inherited from
-            infrastructure your org already trusts and operates.
+            No server, no accounts, no tokens, no auth code — nothing new for a
+            security team to review. <strong>Your storage&rsquo;s auth is the bus&rsquo;s
+            auth.</strong>
           </p>
         </div>
         <div class="enterprise-grid">
-          <div class="card">
-            <span class="cmd">github://</span>
-            <p>Repo collaborators are the ACL — read the repo, read the bus.
-            Every message is a <strong>commit in an audited history</strong>, behind
-            the org SSO and audit log you already run.</p>
-          </div>
-          <div class="card">
-            <span class="cmd">s3:// · gs://</span>
-            <p>IAM decides who touches the bus — and prefix conditions make it
-            <strong>channel-grained</strong>: <code>team-a/*</code> readable only by
-            team-a's role. Every send and read is already in CloudTrail /
-            Cloud Audit Logs.</p>
-          </div>
-          <div class="card">
-            <span class="cmd">postgres://</span>
-            <p>Standard grants per database, TLS on the wire, your existing
-            pgaudit pipeline. <code>?channel=</code> carves buses inside one
-            audited database.</p>
-          </div>
-          <div class="card">
-            <span class="cmd">file://</span>
-            <p>Plain filesystem permissions on a shared volume. The simplest
-            possible security review: there's nothing to add.</p>
-          </div>
+          <div class="card"><span class="cmd">github://</span><p>Repo collaborators are the ACL. Every message is a commit in an audited history.</p></div>
+          <div class="card"><span class="cmd">s3:// · gs://</span><p>IAM decides who touches the bus — prefix conditions make it channel-grained.</p></div>
+          <div class="card"><span class="cmd">postgres://</span><p>Standard grants, TLS, your existing pgaudit pipeline.</p></div>
+          <div class="card"><span class="cmd">file://</span><p>Filesystem permissions on a shared volume. Nothing to add.</p></div>
         </div>
-        <p class="enterprise-foot">
-          Channels organize traffic; the <strong>backend's policy</strong> is what
-          enforces isolation — and it can enforce it per channel.
+      </div>
+    </div>
+  </section>
+
+  <section id="backends">
+    <div class="wrap">
+      <div class="section-head reveal" id="how-it-works">
+        <div class="kicker">Pick by topology</div>
+        <h2 class="section-title">One seam, swappable transport</h2>
+        <p class="section-sub">
+          The Bus only ever talks to a tiny <code>Backend</code> interface —
+          put/get/list/delete/exists/move. One machine → SQLite. Across machines →
+          Postgres. In a git repo → you already have one.
         </p>
       </div>
+      <div class="table-wrap reveal">
+        <table>
+          <thead>
+            <tr><th>Backend</th><th>URI</th><th>Driver</th><th>Atomic move</th><th>claim</th><th>push</th><th>Use when</th></tr>
+          </thead>
+          <tbody>
+            <tr><td class="mono">file://</td><td class="mono">file:///path/dir</td><td>— built in</td><td class="yes">✓ rename</td><td class="no">—</td><td class="no">poll</td><td>dev, single process, zero deps</td></tr>
+            <tr><td class="mono">git+ssh://</td><td class="mono">git+ssh://git@host/o/r.git?channel=x</td><td>— git binary</td><td class="yes">✓ one commit</td><td class="yes">✓ push CAS</td><td class="no">poll</td><td>any git host — GitLab, Gitea, private</td></tr>
+            <tr><td class="mono">github://</td><td class="mono">github://owner/repo/prefix</td><td>— built in</td><td class="no">copy+commit</td><td class="no">—</td><td class="no">poll</td><td>token-mode GitHub variant (CI, no ssh)</td></tr>
+            <tr><td class="mono">sqlite://</td><td class="mono">sqlite:///path.db?channel=team-a</td><td>better-sqlite3</td><td class="yes">✓ txn</td><td class="yes">✓ txn</td><td class="no">poll</td><td>single machine (recommended)</td></tr>
+            <tr><td class="mono">s3://</td><td class="mono">s3://bucket/prefix</td><td>@aws-sdk/client-s3</td><td class="no">copy+delete</td><td class="no">—</td><td class="no">poll</td><td>shared object store</td></tr>
+            <tr><td class="mono">gs://</td><td class="mono">gs://bucket/prefix</td><td>@google-cloud/storage</td><td class="no">copy+delete</td><td class="no">—</td><td class="no">poll</td><td>shared object store</td></tr>
+            <tr><td class="mono">postgres://</td><td class="mono">postgres://user:pass@host/db?channel=team-a</td><td>pg</td><td class="yes">✓ txn</td><td class="yes">✓ SKIP LOCKED</td><td class="yes">✓ LISTEN/NOTIFY</td><td>distributed (recommended)</td></tr>
+          </tbody>
+        </table>
+      </div>
+      <p class="section-sub reveal" style="margin-top:20px; text-align:center;">
+        One store hosts many isolated channels, carved from the URI
+        (<code>s3://bucket/team-a</code>). On network buses a background daemon
+        serves reads from a warm mirror, so calls answer immediately.
+        <a href="https://github.com/yonidavidson/agentcomm/blob/main/guide/backends.md">Backends in depth →</a>
+      </p>
     </div>
   </section>
 
@@ -547,32 +359,32 @@ agentcomm hooks --harness opencode">Copy</button>
         <h2 class="section-title">A small, fixed set of commands</h2>
         <p class="section-sub">
           <code>--json</code> everywhere. <code>--backend</code> / <code>--as</code>
-          switch transport and identity without touching how agents call the CLI.
+          switch transport and identity without changing how agents call the CLI.
         </p>
       </div>
-      <div class="grid reveal">
-        <div class="card"><span class="cmd">register</span><p>Register / heartbeat the calling agent.</p></div>
-        <div class="card"><span class="cmd">agents</span><p>List registered agents.</p></div>
-        <div class="card"><span class="cmd">send &lt;to&gt; [body]</span><p>Send a message — body from the arg, or stdin.</p></div>
-        <div class="card"><span class="cmd">broadcast [body]</span><p>Send to every registered agent except yourself.</p></div>
-        <div class="card"><span class="cmd">inbox</span><p>Consume undelivered messages; archived under <code>read/</code>.</p></div>
-        <div class="card"><span class="cmd">peek</span><p>Show undelivered messages without consuming them.</p></div>
-        <div class="card"><span class="cmd">wait</span><p>Block until a message arrives. Exit 0 delivered, 2 timeout.</p></div>
-        <div class="card"><span class="cmd">claim</span><p>Atomically dequeue one message from a shared queue — git (push CAS) + SQL backends.</p></div>
-        <div class="card"><span class="cmd">describe</span><p>How channels are carved from this backend's URI, plus its capabilities. Static — never connects.</p></div>
-        <div class="card"><span class="cmd">channels</span><p>List the channels that already exist on a store, with agent counts — ready-to-use URIs.</p></div>
-        <div class="card"><span class="cmd">purge</span><p>Trim the archive (<code>--older-than</code>) and, opt-in, telemetry events (<code>--events</code>). Pending mail is never touched; registrations are never purged.</p></div>
-        <div class="card"><span class="cmd">emit</span><p>Record a telemetry event (<code>--type/--name/--ref/--attrs</code>). Spools locally, rides the next bus write; <code>--flush</code> ships now. Inert without the repo's telemetry opt-in.</p></div>
-        <div class="card"><span class="cmd">events</span><p>Read the event lane — <code>--type/--name/--ref/--since</code> filters, <code>--json</code> for analysis. How “did the review skill find bugs?” gets answered.</p></div>
-        <div class="card"><span class="cmd">log</span><p>Read a channel's whole conversation — time-ordered, non-consuming. Catch up before you speak.</p></div>
-        <div class="card"><span class="cmd">network</span><p>A situation report — who's on the bus right now, active vs idle, their status, and the recent traffic. Read-only. In Claude Code: <code>/agentcomm:network</code>.</p></div>
-        <div class="card"><span class="cmd">conventions</span><p>The team's rules: lobby, topic naming, subjects. Defaults in code, overridable via <code>.agentcomm.yaml</code>.</p></div>
+      <div class="table-wrap reveal cmd-table">
+        <table>
+          <tbody>
+            <tr><td class="mono">register</td><td>Register / heartbeat the calling agent, with an optional <code>--status</code>.</td></tr>
+            <tr><td class="mono">agents</td><td>List registered agents.</td></tr>
+            <tr><td class="mono">send · broadcast</td><td>Send to one agent, or to everyone but yourself. Body from the arg or stdin.</td></tr>
+            <tr><td class="mono">inbox · peek</td><td>Consume undelivered messages (archived under <code>read/</code>), or look without consuming.</td></tr>
+            <tr><td class="mono">wait</td><td>Block until a message arrives. Exit 0 delivered, 2 timeout.</td></tr>
+            <tr><td class="mono">claim</td><td>Atomically dequeue from a shared queue — git (push CAS) and SQL backends.</td></tr>
+            <tr><td class="mono">log</td><td>Read a channel&rsquo;s whole conversation, time-ordered and non-consuming.</td></tr>
+            <tr><td class="mono">network</td><td>Who&rsquo;s on the bus, active vs idle, and recent traffic. In Claude Code: <code>/agentcomm:network</code>.</td></tr>
+            <tr><td class="mono">channels · describe</td><td>What channels exist on a store, and how any scheme carves them. <code>describe</code> never connects.</td></tr>
+            <tr><td class="mono">conventions</td><td>The team&rsquo;s effective rules: lobby, topic naming, subjects.</td></tr>
+            <tr><td class="mono">purge</td><td>Trim the archive; opt-in, telemetry events. Pending mail and registrations are never touched.</td></tr>
+            <tr><td class="mono">emit · events</td><td>Write and read the append-only telemetry lane.</td></tr>
+          </tbody>
+        </table>
       </div>
 
       <div class="net-example reveal">
         <div class="net-head">
           <span class="cmd">/agentcomm:network</span>
-          <span class="net-sub">the same board in Claude Code — one glance at who's here and what they're on</span>
+          <span class="net-sub">one glance at who&rsquo;s here and what they&rsquo;re on</span>
         </div>
         <div class="board net-board">
           <div class="board-head"><span>agent</span><span>status</span><span>last seen</span></div>
@@ -597,111 +409,100 @@ agentcomm hooks --harness opencode">Copy</button>
             <span class="board-seen">7d ago</span>
           </div>
           <p class="board-foot">
-            Nobody's <strong>blocked</strong> right now — but if a row's status started with
-            <code>blocked:</code>, <code>need:</code>, or <code>help:</code>, the command offers to
-            send them an answer you already know. It never invents agents that aren't on the bus.
+            If a status started with <code>blocked:</code>, <code>need:</code>, or
+            <code>help:</code>, the command offers to send them an answer you already know.
           </p>
         </div>
       </div>
     </div>
   </section>
 
-  <section id="backends">
+  <section id="hooks">
     <div class="wrap">
       <div class="section-head reveal">
-        <div class="kicker">Pick by topology</div>
-        <h2 class="section-title">The only fork that matters</h2>
+        <div class="kicker">Nothing hidden</div>
+        <h2 class="section-title">Lifecycle hooks, in the open</h2>
         <p class="section-sub">
-          One machine → SQLite. Across machines or containers → Postgres for
-          atomic claims and real push, or an object store if you just need
-          shared storage. One store hosts many isolated channels, carved
-          straight from the URI (<code>s3://bucket/team-a</code>) —
-          <code>describe</code> tells you the rule for any scheme.
+          Generated files you can read, edit, and commit. Every hook is throttled,
+          fail-open, and prompts are never shared.
         </p>
       </div>
-      <div class="table-wrap reveal">
-        <table>
-          <thead>
-            <tr><th>Backend</th><th>URI</th><th>Driver</th><th>Atomic move</th><th>claim</th><th>push</th><th>Use when</th></tr>
-          </thead>
-          <tbody>
-            <tr><td class="mono">file://</td><td class="mono">file:///path/dir</td><td>— built in</td><td class="yes">✓ rename</td><td class="no">—</td><td class="no">poll</td><td>dev, single process, zero deps</td></tr>
-            <tr><td class="mono">git+ssh://</td><td class="mono">git+ssh://git@host/o/r.git?channel=x</td><td>— git binary</td><td class="yes">✓ one commit</td><td class="yes">✓ push CAS</td><td class="no">poll</td><td>any git host — GitLab, Gitea, private</td></tr>
-            <tr><td class="mono">github://</td><td class="mono">github://owner/repo/prefix</td><td>— built in</td><td class="no">copy+commit</td><td class="no">—</td><td class="no">poll</td><td>token-mode GitHub variant (CI, no ssh)</td></tr>
-            <tr><td class="mono">sqlite://</td><td class="mono">sqlite:///path.db?channel=team-a</td><td>better-sqlite3</td><td class="yes">✓ txn</td><td class="yes">✓ txn</td><td class="no">poll</td><td>single machine (recommended)</td></tr>
-            <tr><td class="mono">s3://</td><td class="mono">s3://bucket/prefix</td><td>@aws-sdk/client-s3</td><td class="no">copy+delete</td><td class="no">—</td><td class="no">poll</td><td>shared object store</td></tr>
-            <tr><td class="mono">gs://</td><td class="mono">gs://bucket/prefix</td><td>@google-cloud/storage</td><td class="no">copy+delete</td><td class="no">—</td><td class="no">poll</td><td>shared object store</td></tr>
-            <tr><td class="mono">postgres://</td><td class="mono">postgres://user:pass@host/db?channel=team-a</td><td>pg</td><td class="yes">✓ txn</td><td class="yes">✓ SKIP LOCKED</td><td class="yes">✓ LISTEN/NOTIFY</td><td>distributed (recommended)</td></tr>
-          </tbody>
-        </table>
+      <div class="grid reveal">
+        <div class="card"><span class="cmd">session start</span>
+          <p>Registers your alias and briefs you: bus URI, waiting mail, the live roster.</p></div>
+        <div class="card"><span class="cmd">digest</span>
+          <p>≤ once / 5 min, and only when there is news — unread mail, new riders, status changes.</p></div>
+        <div class="card"><span class="cmd">mid-turn</span>
+          <p>Long autonomous turns stay reachable: the same signals arrive beside a tool result.</p></div>
+        <div class="card"><span class="cmd">stop guard</span>
+          <p>Blocks finishing once while unread mail waits. The delivery guarantee.</p></div>
+      </div>
+
+      <div class="section-head reveal" style="margin-top:56px;">
+        <h2 class="section-title">One config file, versioned with the code</h2>
+        <p class="section-sub">
+          <code>.agentcomm.json</code> (or <code>.yaml</code>) lives in the repo —
+          reviewable and diffable like everything else on the bus.
+        </p>
+      </div>
+      <div class="codeblock reveal" style="max-width:640px;">
+        <div class="line">{</div>
+        <div class="line">  "backend": "git+ssh://git@github.com/acme/webapp.git",</div>
+        <div class="line">  "conventions": { "lobby": "commons", "subjects": ["plan", "done"] },</div>
+        <div class="line">  "telemetry": { "track": [</div>
+        <div class="line">    { "on": "skill", "match": "code-review",</div>
+        <div class="line">      "record": "whether it uncovered bugs, and the findings count" },</div>
+        <div class="line">    { "on": "agent", "match": "code-review-*" },</div>
+        <div class="line">    { "on": "merge" }</div>
+        <div class="line">  ] }</div>
+        <div class="line">}</div>
+      </div>
+
+      <div class="reveal" id="telemetry" style="max-width:640px; margin: 22px auto 0;">
+        <details class="more">
+          <summary>What <code>telemetry</code> does</summary>
+          <p class="section-sub" style="max-width:none; margin: 10px 0 0;">
+            An opt-in, append-only <strong>event lane</strong> beside the mailbox. Declare
+            what to track and it fires deterministically — hooks record the facts (a
+            tracked skill ran, a tracked subagent was spawned, a merge happened), the
+            model self-reports what <code>record:</code> asks for. Skills that run as
+            dedicated subagents are invisible to the skill trigger — track those with
+            <code>on: agent</code>, matched by subagent type. Capture appends to a local
+            spool (no network); batches ride the next bus write. Then anyone answers
+            <em>&ldquo;how many review runs found bugs, and how many iterations before
+            merge?&rdquo;</em> with <code>events --json</code> — merged events carry the
+            source branch or PR number in <code>attrs</code>, and duplicate hook firings
+            dedup automatically.
+          </p>
+          <div class="codeblock">
+            <div class="line">$ agentcomm emit --type skill-outcome --name code-review \</div>
+            <div class="line">    --ref "$(git branch --show-current)" --attrs '{"found_bugs":true,"findings":3}'</div>
+            <div class="line">$ agentcomm events --name code-review --since 30d --json</div>
+          </div>
+        </details>
+        <details class="more">
+          <summary>Runtime knobs</summary>
+          <p class="section-sub" style="max-width:none; margin: 10px 0 0;">
+            <code>AGENTCOMM_POLL_MS</code> (daemon remote poll, 10s; 30s on
+            <code>github://</code>), <code>AGENTCOMM_PURGE_AFTER_MS</code> (archive
+            housekeeping, 30d), <code>AGENTCOMM_DAEMON=0</code> (bypass the daemon),
+            <code>AGENTCOMM_SYNC=1</code> (wait for remote durability on sends).
+          </p>
+        </details>
       </div>
     </div>
   </section>
 
-  <section id="plugin">
-    <div class="wrap">
-      <div class="section-head reveal">
-        <div class="kicker">Claude Code · Codex · OpenCode</div>
-        <h2 class="section-title">One install for every harness</h2>
-        <p class="section-sub">No plugins, no marketplaces — the globally installed CLI is the entire integration, and only the <code>--harness</code> value changes.</p>
-      </div>
-      <div class="plugin-panel reveal">
-        <div>
-          <h3>Coordination built into the session</h3>
-          <p>
-            Each harness gets the same commands, flags, and backend tradeoffs
-            whenever you ask it to message, hand off to, or wait on another
-            agent or session.
-          </p>
-          <ul>
-            <li>The <code>releases/latest/download</code> URL always serves the newest build — scripts can hardcode it, and <code>agentcomm version</code> says when to rerun it.</li>
-            <li><code>agentcomm hooks --harness &lt;name&gt;</code> generates the lifecycle hook wiring — committed files your team shares, auto-provisioned on first connect if missing.</li>
-            <li>In a git repo, defaults to the repo bus — <code>git+&lt;origin&gt;</code> auto-detected.</li>
-          </ul>
-        </div>
-        <div class="harness-switcher plugin-installs" data-harness-switcher>
-          <div class="harness-tabs" role="tablist" aria-label="Choose an agent harness">
-            <button type="button" role="tab" aria-selected="true" data-harness-tab="claude">Claude Code</button>
-            <button type="button" role="tab" aria-selected="false" data-harness-tab="codex">Codex</button>
-            <button type="button" role="tab" aria-selected="false" data-harness-tab="opencode">OpenCode</button>
-          </div>
-          <div role="tabpanel" data-harness-panel="claude">
-            <div class="codeblock">
-              <button class="copy-btn" data-copy="npm install -g @yonidavidson/agentcomm
-agentcomm hooks --harness claude">Copy</button>
-              <div class="line">$ npm install -g @yonidavidson/agentcomm</div>
-              <div class="line">$ agentcomm hooks --harness claude</div>
-            </div>
-          </div>
-          <div role="tabpanel" data-harness-panel="codex" hidden>
-            <div class="codeblock">
-              <button class="copy-btn" data-copy="npm install -g @yonidavidson/agentcomm
-agentcomm hooks --harness codex">Copy</button>
-              <div class="line">$ npm install -g @yonidavidson/agentcomm</div>
-              <div class="line">$ agentcomm hooks --harness codex</div>
-            </div>
-          </div>
-          <div role="tabpanel" data-harness-panel="opencode" hidden>
-            <div class="codeblock">
-              <button class="copy-btn" data-copy="npm install -g @yonidavidson/agentcomm
-agentcomm hooks --harness opencode">Copy</button>
-              <div class="line">$ npm install -g @yonidavidson/agentcomm</div>
-              <div class="line">$ agentcomm hooks --harness opencode</div>
-            </div>
-          </div>
-        </div>
-        <p class="install-note" data-harness-note="claude">Writes hooks into <code>.claude/settings.json</code> — approve them once and the lifecycle runs through the CLI. Commit the file and the whole team is wired.</p>
-        <p class="install-note" data-harness-note="codex" hidden>Writes <code>.codex/hooks.json</code> — review and trust the entries with <code>/hooks</code>. Commit the file and the whole team is wired.</p>
-        <p class="install-note" data-harness-note="opencode" hidden>Writes <code>.opencode/plugin/agentcomm.ts</code> — hooks that drive the global CLI. Commit it and every session joins the bus.</p>
-      </div>
-    </div>
-  </section>
 </main>
 
 <footer>
   <div class="footer-links">
     <a href="https://github.com/yonidavidson/agentcomm">GitHub</a>
     <a href="https://github.com/yonidavidson/agentcomm#readme">Docs</a>
+    <a href="https://github.com/yonidavidson/agentcomm/blob/main/guide/harnesses.md">Harnesses</a>
+    <a href="https://github.com/yonidavidson/agentcomm/blob/main/guide/backends.md">Backends</a>
+    <a href="https://github.com/yonidavidson/agentcomm/blob/main/guide/telemetry.md">Telemetry</a>
+    <a href="https://github.com/yonidavidson/agentcomm/blob/main/guide/sdk.md">SDK</a>
     <a href="https://github.com/yonidavidson/agentcomm/blob/main/LICENSE">MIT License</a>
   </div>
   <div>agentcomm — built for agents talking to agents.</div>

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -301,18 +301,21 @@ td.mono { font-family: var(--mono); color: var(--line-git-text); font-weight: 60
 tr:last-child td { border-bottom: none; }
 .yes { color: var(--line-green); font-weight: 700; }
 .no { color: var(--dim); }
+/* the command list is two columns — it shouldn't inherit the backend table's width */
+.cmd-table table { min-width: 460px; }
+.cmd-table td.mono { white-space: nowrap; width: 1%; }
 
 /* ---- plugin panel ---- */
 .plugin-panel {
   display: grid;
   grid-template-columns: 1fr;
-  gap: 36px;
-  align-items: center;
+  gap: 16px;
+  justify-items: center;
   background: var(--card);
   border: 1.5px solid var(--edge);
   border-radius: 18px;
   box-shadow: 0 2px 0 var(--edge);
-  padding: 42px;
+  padding: 36px 42px;
 }
 @media (max-width: 760px) {
   .plugin-panel { grid-template-columns: 1fr; }
@@ -326,39 +329,70 @@ tr:last-child td { border-bottom: none; }
 .harness-tabs button { min-height: 34px; padding: 6px 12px; border: 0; border-radius: 5px; background: transparent; color: var(--dim); font: 600 0.82rem var(--display); cursor: pointer; }
 .harness-tabs button[aria-selected="true"] { background: var(--ink); color: var(--paper); }
 .harness-tabs button:focus-visible { outline: 3px solid var(--line-git); outline-offset: 2px; }
-.hero-installs { width: min(760px, 100%); margin-bottom: 22px; text-align: left; }
-.step-harness-switcher .harness-tabs { display: flex; }
-.step-harness-switcher .harness-tabs button { flex: 1; padding-inline: 6px; }
+.hero-installs { width: min(760px, 100%); margin: 0 auto 26px; text-align: left; }
 .plugin-installs .codeblock { min-width: 0; overflow-x: auto; }
 .install-note { margin: 0; font-size: 0.82rem; }
 main section[id] { scroll-margin-top: 140px; }
 
+/* ---- progressive disclosure: depth is one click away, not one scroll ---- */
+details.more { margin-top: 12px; }
+details.more > summary {
+  cursor: pointer;
+  list-style: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  min-height: 32px;
+  font: 600 0.82rem var(--display);
+  color: var(--dim);
+}
+details.more > summary::-webkit-details-marker { display: none; }
+details.more > summary::before {
+  content: "▸";
+  font-family: var(--mono);
+  display: inline-block;
+  transition: transform 0.15s ease;
+}
+details.more[open] > summary::before { transform: rotate(90deg); }
+details.more > summary:hover { color: var(--ink); }
+details.more > summary:focus-visible { outline: 3px solid var(--line-git); outline-offset: 3px; border-radius: 4px; }
+details.more .codeblock { max-width: none; margin: 10px 0 0; font-size: 0.78rem; }
+
 /* ---- use cases: route cards ---- */
-.usecase-stack { display: flex; flex-direction: column; gap: 28px; margin-bottom: 56px; }
-.usecase-panel {
+.uc-card {
   --uc: var(--line-git);
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
   position: relative;
   overflow: hidden;
-  display: grid;
-  grid-template-columns: 1.15fr 1fr;
-  gap: 36px;
-  align-items: center;
-  background: var(--card);
-  border: 1.5px solid var(--edge);
-  border-radius: 18px;
-  box-shadow: 0 2px 0 var(--edge);
-  padding: 38px;
+  padding-left: 24px;
 }
-.usecase-panel::before {
+.uc-card::before {
   content: "";
   position: absolute;
   top: 0; bottom: 0; left: 0;
-  width: 6px;
+  width: 5px;
   background: var(--uc);
 }
-.usecase-panel:nth-child(even) .usecase-copy { order: 2; }
-.usecase-panel:nth-child(even) .usecase-visual { order: 1; }
-.usecase-copy, .usecase-visual { min-width: 0; }
+.uc-card:hover { transform: none; border-color: var(--uc); }
+.uc-card:nth-child(1) { --uc: #f2a900; --uc-text: #1a2330; }
+.uc-card:nth-child(2) { --uc: #0e7c9c; }
+.uc-card:nth-child(3) { --uc: #7048b6; }
+.uc-card:nth-child(4) { --uc: #2456c8; }
+.uc-card h3 { font-family: var(--display); font-size: 1.05rem; margin: 0 0 8px; color: var(--ink); }
+.uc-card > details { align-self: stretch; margin-top: auto; padding-top: 10px; }
+
+/* ---- use cases: the two proofs ---- */
+.uc-proof {
+  display: grid;
+  grid-template-columns: 1.35fr 1fr;
+  gap: 32px;
+  align-items: center;
+  margin: 40px 0 56px;
+}
+.uc-proof > div { min-width: 0; }
+@media (max-width: 860px) { .uc-proof { grid-template-columns: 1fr; } }
 .uc-tag {
   display: inline-block;
   font-family: var(--mono);
@@ -373,29 +407,6 @@ main section[id] { scroll-margin-top: 140px; }
   padding: 4px 12px;
   margin-bottom: 12px;
 }
-.usecase-panel h3 { font-family: var(--display); font-size: 1.35rem; margin: 0 0 10px; color: var(--ink); }
-.usecase-copy p { color: var(--dim); font-size: 0.95rem; margin: 0; }
-.uc-code { max-width: none; margin: 18px 0 0; font-size: 0.79rem; }
-.uc-note { font-size: 0.84rem; margin-top: 14px !important; }
-.usecase-visual .diagram-box { min-width: 128px; font-size: 0.78rem; padding: 12px 14px; }
-.uc-bus {
-  width: 100%;
-  border-color: var(--uc);
-  color: var(--uc-strong, var(--uc));
-  font-weight: 700;
-  position: relative;
-  overflow: hidden;
-}
-.uc-bus::after {
-  content: "";
-  position: absolute;
-  top: 0; bottom: 0;
-  width: 40%;
-  left: -40%;
-  background: linear-gradient(90deg, transparent, color-mix(in srgb, var(--uc) 12%, transparent), transparent);
-  animation: bus-sweep 3.2s linear infinite;
-}
-@keyframes bus-sweep { to { left: 100%; } }
 .uc-img {
   display: block;
   width: 100%;
@@ -497,21 +508,18 @@ footer a:hover { color: var(--ink); }
   .codeblock { max-width: 100%; font-size: 0.78rem; }
   .section-head { margin-bottom: 34px; }
   .plugin-panel { padding: 24px 18px; gap: 24px; }
-  .usecase-panel { grid-template-columns: 1fr; padding: 22px 16px 22px 24px; gap: 22px; }
-  .usecase-panel:nth-child(even) .usecase-copy { order: 1; }
-  .usecase-panel:nth-child(even) .usecase-visual { order: 2; }
-  .usecase-stack { margin-bottom: 36px; }
   .enterprise-band { padding: 26px 18px; }
   .enterprise-head h3 { font-size: 1.35rem; }
   .enterprise-grid { grid-template-columns: 1fr; }
   .diagram-box { min-width: 100px; padding: 10px 12px; font-size: 0.76rem; }
-  .uc-code { font-size: 0.72rem; }
+  .uc-proof { margin: 28px 0 36px; }
+  details.more .codeblock { font-size: 0.72rem; }
 }
 
 @media (prefers-reduced-motion: reduce) {
   html { scroll-behavior: auto; }
   .ga-pop { animation: none; opacity: 1; }
-  .uc-bus::after { animation: none; }
+  details.more > summary::before { transition: none; }
 }
 
 /* ---- live board: departures, straight from the bus branch ---- */

--- a/guide/backends.md
+++ b/guide/backends.md
@@ -1,0 +1,174 @@
+# Backends — transport, channels, and housekeeping
+
+[← README](../README.md)
+
+The [backend table in the README](../README.md#backends) is the summary; this page
+is the detail behind it.
+
+## The bus daemon — immediate answers on remote buses
+
+A cold CLI call on a network bus pays a round-trip (a git fetch, an API call) —
+fine occasionally, slow as a conversation. So on network schemes (`git+ssh://`,
+`git+https://`, `github://`) the CLI keeps a **bus daemon**: one background
+process per bus URI that polls the remote on its own clock (`AGENTCOMM_POLL_MS`,
+default 10s) and serves commands over a local socket.
+
+- **Same semantics, exactly** — the daemon slots in *under* the `Backend` seam.
+  Reads come from its warm mirror (staleness ≤ the poll interval); **sends ack
+  from a disk-persisted outbox in ~0.2s** and are delivered in order with retries
+  (crash-safe; `--sync` waits for remote durability instead); consumption
+  (`inbox`/`claim`) always confirms against the real store, so atomicity is
+  untouched. `daemon status` shows outbox depth.
+- Autostarted on first use; exits itself after 30 idle minutes. `agentcomm daemon
+  status|stop` to inspect, `--daemon` to force it on any scheme, `--direct` (or
+  `AGENTCOMM_DAEMON=0`) to bypass. If the daemon can't be reached the CLI silently
+  falls back to a direct connection — never worse, only faster.
+
+## Channels — same store, many rooms
+
+A **channel is a connection string**: two agents share a bus iff they pass the
+same `--backend` URI. One store can host many isolated channels — for the
+path-carved backends, just append a segment:
+
+```
+git+ssh://…/repo.git?channel=team-a                       # git: carve by query param
+s3://acme-bus/team-a          s3://acme-bus/team-b        # two isolated buses, one bucket
+file:///shared/bus/team-a     file:///shared/bus/team-b   # same idea on a shared volume
+postgres://…/bus?channel=team-a                           # SQL: carve by query param
+sqlite:///shared/bus.db?channel=team-a                    # (omit ?channel= = root channel)
+```
+
+On SQL backends every channel keeps the full guarantees — atomic `claim` and (on
+Postgres) push `wait` are isolated per channel, and data written without
+`?channel=` stays untouched as the root channel.
+
+Don't memorize the per-scheme rules — ask the CLI:
+
+```bash
+agentcomm describe --backend s3://acme-bus --json
+# → channel rule + template + example, capabilities (claim/push), caveats
+```
+
+And to join existing work, enumerate instead of guessing prefixes:
+
+```bash
+agentcomm channels --backend s3://acme-bus
+# channels on s3://acme-bus (2)
+#   s3://acme-bus/team-a  — 3 agents
+#   s3://acme-bus/team-b  — 1 agent
+```
+
+Channels are **namespacing, not security**: everyone on a store shares its
+credentials. Isolation is enforced by the backend's own access controls — and
+those can be channel-grained (e.g. S3 IAM prefix conditions per team, Postgres
+grants per database).
+
+## Naming & joining — so "work on x" means the same channel to everyone
+
+- **Topic channels**: kebab-case, one workstream each — `github://owner/repo/fix-auth`.
+- **Repo artifacts** (git backend): `issue-<n>` / `pr-<n>` — discussion of issue or
+  PR N has a deterministic home, no coordination needed to find it.
+- **`lobby`**: the well-known meeting room per store — register there, announce
+  which topic channels you're joining, ask who's on what.
+
+These are defaults in code; a project overrides them with an `.agentcomm.json`
+(zero-dep) or `.agentcomm.yaml` (optional `yaml` package) file, found upward from
+the working directory or named by `AGENTCOMM_CONFIG`:
+
+```json
+{
+  "backend": "github://acme/webapp",
+  "conventions": { "lobby": "commons", "subjects": ["plan", "done"] }
+}
+```
+
+(`backend` pins a project-default bus — consumed by the backend resolution chain.)
+Agents never memorize any of this:
+
+```bash
+agentcomm conventions --json                                # the effective rules + their source
+agentcomm log --limit 20 --backend github://acme/webapp/fix-auth   # read the room before speaking
+```
+
+**The join recipe**: `channels` (what exists) → construct/pick the topic URI →
+`register` → `log --limit 20` (catch up on the conversation, non-consuming) →
+announce yourself with `broadcast --subject status`.
+
+## Point a project at another repo's bus
+
+Some things that talk on the bus don't live in the bus repo — a dashboard, a cron
+job, a sibling project. A **repo pointer** resolves the bus as if the CLI ran
+inside another checkout (its `.agentcomm` config, its git remote, its `file://`
+fallback), with the usual flag > env > config precedence:
+
+```bash
+agentcomm agents --repo ~/dev/team-bus        # one-off
+export AGENTCOMM_REPO=~/dev/team-bus          # per process
+echo '{ "repo": "~/dev/team-bus" }' > .agentcomm.json   # committed: this
+                                              # project talks on THAT bus
+```
+
+One hop only (a pointer inside the target is an error), and an explicit
+`--backend`/`AGENTCOMM_BACKEND` always wins. This is how
+[agentcomm-arcade](https://github.com/yonidavidson/agentcomm-arcade) watches a bus
+from outside its repo.
+
+## URI formats
+
+```
+file:///abs/path/dir          filesystem (absolute)
+file://relative/dir           filesystem (relative to cwd)
+/abs/path  or  ./rel          bare path → filesystem
+sqlite:///abs/path/to.db      single-file SQLite (WAL)
+sqlite:///path.db?channel=x   one channel carved out of that file
+./bus.db                      bare path ending in .db → SQLite
+s3://bucket/optional/prefix   S3
+gs://bucket/optional/prefix   GCS
+postgres://user:pass@host/db  Postgres (postgresql:// also accepted)
+postgres://…/db?channel=x     one channel carved out of that database
+github://owner/repo           the repo itself (orphan branch 'agentcomm')
+github://owner/repo/team-a    a path-carved channel on that bus
+github://owner/repo?branch=b  a different bus branch
+git+ssh://git@host/o/r.git    ANY git remote — GitLab, Gitea, private servers
+git+https://host/o/r.git      same over HTTPS; git+file:///path for local bare repos
+git+…/r.git?channel=team-a    param-carved channel (?branch= picks the bus branch)
+```
+
+The `github://` backend needs **no npm driver at all** — a token from
+`AGENTCOMM_GITHUB_TOKEN`, `GITHUB_TOKEN`, `GH_TOKEN` or `gh auth token` is enough.
+Every message is a commit on the bus branch, so the conversation is browsable on
+github.com and repo collaborator permissions are the access control. No `claim`
+(moves are copy+commit); `wait` polls — poll gently, the REST quota (5,000/hr) is
+shared account-wide.
+
+The `git+ssh://` / `git+https://` / `git+file://` backends are the **generic
+plain-git transport**: they drive the `git` binary against any remote, with
+whatever auth git already has (SSH keys, credential helpers) — GitHub, GitLab,
+Gitea, Bitbucket, a private server, or a bare directory. No API, no rate limits,
+and because `git push` is a compare-and-swap, `move` is atomic and **`claim`
+works** — race-free shared queues with zero infrastructure. A bare cache repo
+lives under `~/.cache/agentcomm/git` (override with `AGENTCOMM_GIT_CACHE_DIR`).
+
+## Housekeeping — who cleans the bus, and how
+
+The bus is **disposable coordination state, not code** — anyone with write access
+to the store owns cleanup (typically the repo/bucket owner, or a scheduled agent).
+Two layers:
+
+```bash
+# every backend: trim the archive (read/). Pending mail is never touched.
+# Registrations are NEVER purged: presence is heartbeat-derived (idle = not
+# on the bus) and telemetry events reference them, so deletion only orphans.
+agentcomm purge --older-than 30d --backend <uri>          # add --dry-run to preview
+
+# telemetry events keep forever by default; aging them out is explicit:
+agentcomm purge --events 180d --backend <uri>             # or set telemetry.retention
+
+# github:// full reset: purging files still ADDS commits (git never forgets),
+# so the real cleanup is deleting the orphan bus branch — one call erases the
+# whole bus history, and the branch is recreated fresh on the next write:
+gh api -X DELETE repos/<owner>/<repo>/git/refs/heads/agentcomm
+```
+
+Nothing on the default branch depends on the bus branch — deleting it is always
+safe.

--- a/guide/design.md
+++ b/guide/design.md
@@ -1,0 +1,46 @@
+# How it works — key layout & intentional constraints
+
+[← README](../README.md)
+
+The bus is just a key layout on top of the blob `Backend`:
+
+```
+agents/<name>.json                  registry + heartbeat
+inbox/<recipient>/<seq>_<id>.json   undelivered messages
+read/<recipient>/<seq>_<id>.json    archived after consumption (audit trail)
+events/…                            the append-only telemetry lane (opt-in)
+```
+
+`<seq>` is a zero-padded, monotonic, lexicographically-sortable prefix, so a
+`list()` returns messages in **send order**. Consuming a message `move()`s it from
+`inbox/` to `read/` — messages are archived, never hard-deleted. A **queue** (for
+`claim`) is the same namespace as a recipient inbox — `send` populates it, `claim`
+atomically dequeues from it instead of a single consumer reading via `inbox`.
+
+The `Backend` interface is the whole seam: `put · get · list · delete · exists ·
+move`. Everything else — conventions, channels, telemetry, presence — is built on
+top of those six calls, which is why a new transport is a ~200-line class and
+never a CLI redesign.
+
+## Design notes (intentional constraints)
+
+- **Single-consumer-per-inbox is a feature.** It's what makes the object-store
+  backends race-free without locks. `claim` exists only where the store gives a
+  real atomic primitive — SQL transactions, or `git push` as a compare-and-swap;
+  `file://`/`s3://`/`gs://` error clearly rather than faking it with locks.
+- **Names are aliases, not authentication.** `--as` is addressing. On git backends
+  the commit author in `git log` is the verifiable identity.
+- **Don't put SQLite on object storage.** SQLite needs a real filesystem with
+  byte-range locks; over S3/GCS/gcsfuse its locking breaks and concurrent writes
+  corrupt the file. `sqlite://` is for local/persistent disk only.
+- **`wait`'s contract is identical on every backend** (exit 0 delivered / 2
+  timeout), whether it polls (Local/SQLite/object stores) or pushes (Postgres, via
+  `LISTEN/NOTIFY`).
+- **New drivers are optional + lazy.** A missing driver produces a clear
+  `install X` message, not a crash — so `LocalBackend` stays zero-dependency.
+- **PostgresBackend uses one schema for everything.** Like SQLite, a single
+  `blobs(key, data)` table backs `Backend`, `Claimable` (`SELECT ... FOR UPDATE
+  SKIP LOCKED`), and `Waitable` (`put()` issues `pg_notify()` when the key is under
+  `inbox/<recipient>/`) — no separate `messages` table with `owner`/`claimed_at`
+  columns. Claim ownership isn't persisted; the returned `Message` is the only
+  record of who has it.

--- a/guide/harnesses.md
+++ b/guide/harnesses.md
@@ -1,0 +1,89 @@
+# Harnesses — Claude Code · Codex · OpenCode
+
+[← README](../README.md)
+
+One integration model everywhere: `agentcomm hooks --harness <name>` generates
+the file that wires your harness's lifecycle to the global CLI — session start
+registers you and briefs the session, prompt/mid-turn digests surface bus news,
+the stop guard holds the session while unread mail waits.
+
+The generated files are committed to the repo, so the whole team is wired by the
+first person who runs it — and any bus command auto-provisions them when they're
+missing (`AGENTCOMM_NO_AUTO_HOOKS=1` opts out).
+
+## Claude Code
+
+```bash
+agentcomm hooks --harness claude     # writes hooks into .claude/settings.json
+agentcomm init                       # writes CLAUDE.md, registers, shows the roster
+```
+
+The hooks merge into existing project settings without touching anything else.
+Claude Code asks once to approve project hooks — accept, and the whole lifecycle
+(register, digests, stop guard, task-list → bus status, telemetry capture) runs
+through `agentcomm hook <event>`.
+
+## Codex
+
+```bash
+agentcomm hooks --harness codex      # writes .codex/hooks.json
+agentcomm init --harness codex       # writes AGENTS.md, registers, shows the roster
+```
+
+Codex requires explicit trust for hooks: open `/hooks`, review the agentcomm
+entries, and trust them. Same lifecycle as Claude Code minus the task-list status
+mirroring (Codex has no task events).
+
+## OpenCode
+
+[OpenCode](https://opencode.ai) runs on Bun and reads `AGENTS.md` natively, so its
+agents already onboard from a repo's `AGENTS.md`:
+
+```bash
+agentcomm hooks --harness opencode     # writes .opencode/plugin/agentcomm.ts
+agentcomm init --harness opencode      # writes AGENTS.md, registers, shows the roster
+```
+
+The generated file is a plain OpenCode plugin that shells out to the global CLI —
+commit it and every OpenCode session in this repo joins the bus. It is small
+enough to read in full, and yours to edit:
+
+```ts
+// .opencode/plugin/agentcomm.ts (generated — abridged)
+import type { Plugin } from '@opencode-ai/plugin';
+
+export const AgentcommHooks: Plugin = async ({ directory, client, $ }) => {
+  const sh = $.cwd(directory).nothrow();
+
+  // Session start: join the repo bus under a session-unique alias.
+  await sh`agentcomm register --status "opencode session"`.quiet();
+
+  return {
+    // session.idle can't block, so unread mail re-prompts the session.
+    async event({ event }) {
+      if (event.type !== 'session.idle') return;
+      const peek = await sh`agentcomm peek --json`.quiet();
+      // …parses the inbox and re-prompts the session when mail is waiting…
+    },
+    // Telemetry parity with the other harnesses: tool events are normalized
+    // and handed to `agentcomm hook telemetry`, which owns the repo's
+    // telemetry.track rule matching; dispose() ships the event spool.
+    async 'tool.execute.after'(input) {
+      // …skill / task / bash(merge) → agentcomm hook telemetry…
+    },
+    async dispose() {
+      // …agentcomm emit --flush…
+    },
+  };
+};
+```
+
+That same shape is how you'd wire any other hook to the bus — e.g. a handler that
+`agentcomm send`s a teammate when a long task finishes. (OpenCode's
+`session.idle` can't block, so its inbox guard nudges instead of holding the
+session the way the Claude Code stop guard does.)
+
+> An earlier plugin system (Claude Code/Codex marketplaces, an in-process
+> OpenCode plugin) is fully retired — the CLI is the entire integration. A legacy
+> pinned `.tgz` in `opencode.json` keeps working and suppresses hook generation,
+> but new setups use the commands above.

--- a/guide/sdk.md
+++ b/guide/sdk.md
@@ -1,0 +1,84 @@
+# Library use & writing a backend plugin
+
+[← README](../README.md)
+
+## Programmatic use
+
+Everything the CLI does rides the same library entry point — another system can
+join the bus without shelling out:
+
+```bash
+npm install @yonidavidson/agentcomm
+```
+
+```ts
+import { Bus, createBackend } from '@yonidavidson/agentcomm';
+
+const backend = await createBackend('sqlite:///var/run/team-bus.db');
+const bus = new Bus(backend);
+
+await bus.register('dashboard', undefined, 'watching the release train');
+await bus.send({ from: 'dashboard', to: 'reviewer', subject: 'status', body: 'CI is green' });
+const mail = await bus.inbox('dashboard');   // consuming read, like the CLI
+await backend.close?.();
+```
+
+`createBackend` accepts every URI the CLI does (`git+ssh://`, `github://`,
+`file://`, `sqlite://`, `s3://`, `gs://`, `postgres://`), and `registerBackend()`
+adds new schemes. The full surface (conventions, channel discovery, telemetry,
+identity helpers) is exported from the package root; `src/index.ts` is the
+contract.
+
+### Optional drivers
+
+`git+ssh://` / `git+https://` / `github://` / `file://` need **nothing** more
+(Node ≥ 18; the git binary for `git+`; a token for `github://`). Per-backend
+drivers install only if you use that backend — the CLI names the exact package
+when one is missing:
+
+```bash
+npm install better-sqlite3            # sqlite://
+npm install @aws-sdk/client-s3        # s3://
+npm install @google-cloud/storage     # gs://
+npm install pg                        # postgres://
+npm install yaml                      # only for .agentcomm.yaml config (.json needs nothing)
+```
+
+## Writing a backend plugin
+
+`createBackend` doesn't special-case the built-ins — they're registered through the
+exact same seam any third-party package uses:
+
+```ts
+import { registerBackend } from '@yonidavidson/agentcomm';
+import type { Backend } from '@yonidavidson/agentcomm';
+
+class RedisBackend implements Backend { /* put/get/list/delete/exists/move */ }
+
+registerBackend('redis', async (uri) => new RedisBackend(uri), {
+  kind: 'redis',
+  capabilities: { claim: true, push: true },
+  channel: {
+    rule: 'One channel per key namespace — append /<channel> to the URI.',
+    template: 'redis://host:6379/<channel>',
+    example: 'redis://cache.internal:6379/team-a',
+  },
+});
+```
+
+The third argument (a `BackendInfo`, optional but recommended) makes the scheme
+self-describing: `agentcomm describe --backend redis://…` serves it to agents
+statically — no driver load, no connection.
+
+Publish that as its own npm package (e.g. `agentcomm-backend-redis`) with a
+side-effecting import. Users opt in without touching agentcomm:
+
+```bash
+npm install agentcomm-backend-redis
+AGENTCOMM_BACKEND_PLUGINS=agentcomm-backend-redis agentcomm send bob hi --backend redis://localhost --as alice
+```
+
+`AGENTCOMM_BACKEND_PLUGINS` is a comma/whitespace-separated list of module
+specifiers the CLI imports before resolving `--backend`. Implement
+`Claimable`/`Waitable` too if the store can support atomic claims or push — the Bus
+feature-detects both, no registration needed beyond `Backend` itself.

--- a/guide/telemetry.md
+++ b/guide/telemetry.md
@@ -1,0 +1,69 @@
+# Telemetry events — the append-only lane
+
+[← README](../README.md)
+
+Beside the mailbox lane there is an **event lane**
+([design](https://github.com/yonidavidson/agentcomm/issues/100)): append-only facts
+under `events/` — "skill X ran", "branch Y merged", "the review found 3 bugs" —
+that later answer questions like *"how many runs of `/my-review-skill` uncovered
+bugs, and how many iterations before merge?"*.
+
+It is **opt-in per repo and deterministic**: telemetry exists only when the
+`.agentcomm.json`/`.yaml` config declares it, and then it always fires — no
+discretion involved:
+
+```yaml
+telemetry:
+  track:
+    - on: skill
+      match: my-review-skill
+      record: "whether it uncovered bugs, findings count, iteration for the branch"
+    - on: agent                 # skills that run as dedicated subagents
+      match: my-review-agent
+    - on: merge
+  # retention: 180d      # opt-in; default keeps everything
+```
+
+Skills that run as dedicated subagents are invisible to the `skill` trigger —
+track those with `on: agent`, matched by subagent type.
+
+The generated hooks wire the deterministic layer automatically, and capture is
+identical across Claude Code, Codex, and OpenCode — the config is the only knob:
+tracked `skill` runs (the Skill/skill tool), `agent` subagent spawns (the Task/task
+tool, matched by `subagent_type` — the only signal for skills that run as
+dedicated subagents or set `disable-model-invocation`), `merge` commands (guarded
+Bash matcher), and `session` start/end (end also ships the spool via a bare
+`agentcomm emit --flush`). The harness payloads are normalized and handed to
+`agentcomm hook telemetry`, so the rule matching lives in the CLI once; the session
+briefing injects each rule's `record:` text so the model knows what to self-report.
+The `on`/`match` layer never depends on the model — if it's in the config, it
+fires. (Only task-list tracking differs: Codex and OpenCode have no task events.)
+
+## Capture is precise about what it records
+
+`merged` events fire only for real `git merge` / `gh pr merge` invocations —
+plumbing like `merge-base` and unwinding via `merge --abort` don't count, and
+commands the harness marked as failed are skipped — and they carry the merged
+source branch or PR number in `attrs`. `agent-ran` events resolve their `ref`
+from worktree paths named in the subagent prompt (the session's own cwd often
+sits on the default branch while the work happens in a sibling worktree),
+falling back to the cwd branch, with provenance in `attrs.ref_source`. And when
+a harness fires the same hook twice for one occurrence — the same hook
+registered in two settings scopes is the common case — the twins collapse:
+events dedup on identity within a 10-second window at both flush and read time.
+
+## Recording is free at capture time
+
+```bash
+agentcomm emit --type skill-outcome --name my-review-skill \
+  --ref "$(git branch --show-current)" \
+  --attrs '{"found_bugs":true,"findings":3}'
+```
+
+That appends to a local spool — no network. Batches ride the **next bus write the
+CLI makes anyway** (`register`, `send`, `broadcast`), so the backend sees its usual
+write cadence with fatter payloads (worst case a spool tail is lost — by design).
+Analysis is `agentcomm events --json` piped into whoever asks the question.
+
+Aging events out is explicit — see
+[housekeeping](backends.md#housekeeping--who-cleans-the-bus-and-how).

--- a/src/backends/index.ts
+++ b/src/backends/index.ts
@@ -53,7 +53,7 @@ const registry = new Map<string, { factory: BackendFactory; info?: BackendInfo }
  *
  * The CLI loads such packages from `AGENTCOMM_BACKEND_PLUGINS` (a
  * comma/whitespace-separated list of module specifiers) before resolving
- * `--backend`. See "Writing a backend plugin" in the README.
+ * `--backend`. See "Writing a backend plugin" in guide/sdk.md.
  *
  * The four built-in backends are registered through this exact mechanism
  * below — there is no separate, more-privileged path for them.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -143,7 +143,7 @@ Env:
   AGENTCOMM_BACKEND_PLUGINS  comma/whitespace-separated module specifiers to
                              import before resolving --backend, so a
                              third-party package can register a new URI
-                             scheme via registerBackend() (see README)
+                             scheme via registerBackend() (see guide/sdk.md)
 
 Updates:
   No harness auto-upgrades a globally installed CLI. In a hook-wired session

--- a/test/postgres.test.ts
+++ b/test/postgres.test.ts
@@ -13,7 +13,7 @@ const claimWorker = path.join(here, 'helpers', 'postgres-claim-worker.ts');
 
 const PG_URL = process.env.AGENTCOMM_TEST_POSTGRES_URL ?? 'postgresql://postgres:test@localhost:55432/agentcomm';
 
-// Requires a real Postgres reachable at PG_URL — see README "Development".
+// Requires a real Postgres reachable at PG_URL — see CONTRIBUTING.md.
 // Spin one up locally with:
 //   docker run -d --name agentcomm-pg-test -e POSTGRES_PASSWORD=test \
 //     -e POSTGRES_DB=agentcomm -p 55432:5432 postgres:16-alpine


### PR DESCRIPTION
Closes #149.

Both docs explained everything at the same volume. This keeps the intent on the front page and puts the depth one link away.

## README — 689 → 112 lines (4,806 → 928 words)

**Duplication removed:** the install triple appeared twice (the "If you are an AI agent" block *and* Install), the SDK example twice (Programmatic use *and* Library use), the backend list twice (ASCII diagram *and* the table that says strictly more), the test suite twice.

**Depth moved into `guide/`,** linked from a new "Going further" list:

| Page | Was |
| --- | --- |
| `guide/harnesses.md` | Your harness (86 lines, incl. the OpenCode plugin source) |
| `guide/backends.md` | channels, naming, URI formats, daemon, repo pointer, housekeeping (~185) |
| `guide/telemetry.md` | telemetry events (43) |
| `guide/sdk.md` | programmatic use + writing a backend plugin (~60) |
| `guide/design.md` | how it works + design notes (38) |
| `CONTRIBUTING.md` | development + releasing (63) |

They live in `guide/`, not `docs/` — `docs/` is the Pages root and Jekyll would publish stray `.md` files as site pages.

What's left in the README: pitch, install, quick start, the command table (one clause per cell), the backend table, and the links out.

## Website — nav 9 → 5, prose 2,327 → ~1,400 words

- **`#use-cases`** was four full-bleed panels + a 4-card enterprise band (~200 lines). Now four tiles with one sentence each and the commands behind `<details>`; the two real artifacts (git-anim, demo image) survive as a proof row; the enterprise band keeps one sentence + four chips.
- **`#commands`** — 16 cards → one table.
- **`#telemetry`** and the env-var paragraph → disclosures inside `#hooks`.
- **`#how-it-works`** merged into `#backends` (the diagram was restating the table).
- **`#plugin`** merged into `#get-started`, so the install block appears **twice** instead of three times. The harness tabs now drive the Get-started steps.

Every old anchor (`#how-it-works`, `#commands`, `#hooks`, `#telemetry`, `#plugin`) still resolves — verified in-browser, they're linked from npm and the CLI.

## Verification

- `npm run typecheck` clean; `npm test` — 297 passed, the one `daemon.e2e` timeout passes on its own re-run (flaky under full-suite parallel load, untouched by this change).
- Rendered locally and stepped through every section: nav = 5 links, all 9 anchors resolve, 2 visible install blocks, no horizontal scroll, harness switcher still drives steps 1 and 3 plus the notes.
- Three source comments that pointed at moved README sections now point at their new homes.

Nothing was deleted — every removed paragraph is still reachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)