### PR TITLE
release prep: 0.19.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yonidavidson/agentcomm",
-  "version": "0.19.2",
+  "version": "0.19.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@yonidavidson/agentcomm",
-      "version": "0.19.2",
+      "version": "0.19.3",
       "license": "MIT",
       "bin": {
         "agentcomm": "dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yonidavidson/agentcomm",
-  "version": "0.19.2",
+  "version": "0.19.3",
   "description": "A tiny mailbox/message bus for AI agents that shell out to one CLI. Pluggable storage backends behind a single Backend interface.",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
Version bump only — the release-cut dispatch follows once this is on `main`.

**Why now:** `README.md` is in the package's `files` list, so npmjs.com renders whatever the last release carried. Two docs changes landed *after* v0.19.2 was cut (2026-07-23 21:21):

- #148 — `on:agent` + v0.19.2 telemetry precision coverage
- #150 — the README/website compression (README 689 → 112 lines; site nav 9 → 5)

Until this ships, the registry page still shows the old 689-line README, which is exactly the thing #149 set out to fix.

**No functional change.** The only `src/` edits in the range are three comment/help-text pointers that moved with their sections (`see README` → `guide/sdk.md`, `CONTRIBUTING.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)