### PR TITLE
release prep: 0.20.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yonidavidson/agentcomm",
-  "version": "0.19.3",
+  "version": "0.20.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@yonidavidson/agentcomm",
-      "version": "0.19.3",
+      "version": "0.20.0",
       "license": "MIT",
       "bin": {
         "agentcomm": "dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yonidavidson/agentcomm",
-  "version": "0.19.3",
+  "version": "0.20.0",
   "description": "A tiny mailbox/message bus for AI agents that shell out to one CLI. Pluggable storage backends behind a single Backend interface.",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
Version bump for the 0.20.0 release. Main is protected, so the bump rides CI as a normal PR before the `release-cut.yml` dispatch.

**Breaking:** `agentcomm hooks` is gone, replaced by `agentcomm install` (#152, PR #153). Repos wired by the old command re-run `agentcomm install` and delete the old agentcomm block from `.claude/settings.json`, or the lifecycle fires twice.

Headline of the release: harness wiring now **upgrades**. `install` rewrites its own wiring instead of writing once and never again, and connect-time provisioning refreshes stale wiring — so lifecycle hooks added in a release reach repos wired long before it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)