### PR TITLE
fix: stop the session alias from drifting mid-session (#157)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,7 +7,8 @@ import { Bus } from './bus.js';
 import { parseArgs, resolveConfig, type ParsedFlags, type ResolvedConfig } from './config.js';
 import type { Backend, Message } from './types.js';
 import { fileURLToPath } from 'node:url';
-import { deriveIdentity, sessionHash } from './identity.js';
+import { deriveIdentity, pinnedSession, sessionHash } from './identity.js';
+import { recordAlias } from './session.js';
 import { INSTALL_COMMAND } from './update-check.js';
 import {
   EVENTS_PREFIX,
@@ -1088,14 +1089,14 @@ async function cmdBroadcast(
 async function cmdInbox(bus: Bus, cfg: ResolvedConfig): Promise<number> {
   const me = await resolveAgent(cfg);
   const messages = await bus.inbox(me);
-  printMessages(messages, cfg);
+  printMessages(messages, cfg, me);
   return 0;
 }
 
 async function cmdPeek(bus: Bus, cfg: ResolvedConfig): Promise<number> {
   const me = await resolveAgent(cfg);
   const messages = await bus.peek(me);
-  printMessages(messages, cfg);
+  printMessages(messages, cfg, me);
   return 0;
 }
 
@@ -1107,7 +1108,7 @@ async function cmdWait(bus: Bus, cfg: ResolvedConfig, timeoutMs: number): Promis
     else process.stderr.write(`wait: timed out after ${timeoutMs}ms\n`);
     return 2; // timeout
   }
-  printMessages(messages, cfg);
+  printMessages(messages, cfg, me);
   return 0; // delivered
 }
 
@@ -1277,13 +1278,15 @@ async function loadBackendPlugins(): Promise<void> {
 
 // ── helpers ─────────────────────────────────────────────────────────────────
 
-function printMessages(messages: Message[], cfg: ResolvedConfig): void {
+function printMessages(messages: Message[], cfg: ResolvedConfig, recipient?: string): void {
   if (cfg.json) {
     emit(messages);
     return;
   }
   if (messages.length === 0) {
-    process.stdout.write('(no messages)\n');
+    // Name the mailbox that was read: "no messages" reads as "no mail
+    // anywhere", which is exactly how a drifted alias hides (issue #157).
+    process.stdout.write(recipient ? `(no messages for ${recipient})\n` : '(no messages)\n');
     return;
   }
   for (const m of messages) {
@@ -1311,6 +1314,19 @@ async function resolveAgent(cfg: ResolvedConfig): Promise<string> {
       process.stderr.write(
         `agentcomm: acting as ${derivedIdentity} (${source} + session; --as or AGENTCOMM_AGENT overrides)\n`,
       );
+      // Alias drift is invisible from the read side — a different name is a
+      // different, EMPTY mailbox while mail keeps arriving at the old one
+      // (issue #157). The fingerprint is sticky now, so this fires only when
+      // the identity itself changed underneath us; say which name has the mail.
+      if (!pinnedSession()) {
+        const previous = await recordAlias(await sessionHash(), derivedIdentity).catch(() => null);
+        if (previous) {
+          process.stderr.write(
+            `agentcomm: NOTE — acting as ${derivedIdentity}, but this session previously acted as ${previous}. ` +
+              `Mail sent to ${previous} is in ${previous}'s mailbox: read it with \`--as ${previous}\`.\n`,
+          );
+        }
+      }
     }
   }
   if (!derivedIdentity) {

--- a/src/hook-run.ts
+++ b/src/hook-run.ts
@@ -42,36 +42,6 @@ async function readStdinJson(): Promise<HookInput> {
   }
 }
 
-/**
- * Align the derived alias with the agent's own Bash commands. Both inherit
- * the terminal-session env, so usually nothing is needed; in the gppid
- * fallback the agent's CLI lands on the harness pid — our ancestor too.
- */
-async function sessionEnv(): Promise<Record<string, string>> {
-  if (
-    process.env.AGENTCOMM_SESSION ||
-    process.env.ITERM_SESSION_ID ||
-    process.env.TERM_SESSION_ID ||
-    process.env.TMUX_PANE
-  ) {
-    return {};
-  }
-  try {
-    const ps = (pid: number | string, field: string): Promise<string> =>
-      new Promise((res, rej) =>
-        execFile('ps', ['-o', `${field}=`, '-p', String(pid)], (e, out) => (e ? rej(e) : res(out.trim()))),
-      );
-    const parent = process.ppid;
-    const comm = await ps(parent, 'comm');
-    // hooks run as `sh -c agentcomm …` or as a direct child of the harness;
-    // the harness process is the first non-shell ancestor
-    const harness = /(^|\/)(sh|bash|zsh|dash)$/.test(comm) ? await ps(parent, 'ppid') : String(parent);
-    return { AGENTCOMM_SESSION: `gppid:${harness}` };
-  } catch {
-    return {};
-  }
-}
-
 interface CliResult {
   json: unknown;
   stderr: string;
@@ -84,7 +54,11 @@ interface CliResult {
  */
 async function cli(args: string[], cwd: string, timeoutMs = 10_000): Promise<CliResult | null> {
   try {
-    const env = { ...process.env, ...(await sessionEnv()) };
+    // No session pinning here: the CLI's sticky session state (issue #157)
+    // recognises the harness process as a shared ancestor of both this hook's
+    // child and the agent's own Bash commands, so both land on ONE mailbox
+    // however deep either happens to run.
+    const env = process.env;
     return await new Promise((resolve) => {
       const child = execFile(
         process.execPath,

--- a/src/identity.ts
+++ b/src/identity.ts
@@ -11,33 +11,46 @@ import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import { createHash } from 'node:crypto';
 import * as os from 'node:os';
+import { stickySession } from './session.js';
 
 const execFileP = promisify(execFile);
 
 let sessionHashMemo: string | undefined;
 
-/**
- * A fingerprint of THIS session, stable across the many invocations one agent
- * session makes: AGENTCOMM_SESSION, else the terminal session id, else the
- * harness process (grandparent pid). Suffixes derived aliases and is recorded
- * in registrations, so tooling can tell "stale me" from "someone else".
- */
-export async function sessionHash(): Promise<string> {
-  if (sessionHashMemo !== undefined) return sessionHashMemo;
-  let session =
+/** An explicitly pinned session id (env), or '' when we have to derive one. */
+export function pinnedSession(): string {
+  return (
     process.env.AGENTCOMM_SESSION ??
     process.env.ITERM_SESSION_ID ??
     process.env.TERM_SESSION_ID ??
     process.env.TMUX_PANE ??
-    '';
-  if (!session) {
-    try {
-      session = 'gppid:' + (await execFileP('ps', ['-o', 'ppid=', '-p', String(process.ppid)])).stdout.trim();
-    } catch {
-      session = 'ppid:' + String(process.ppid);
-    }
+    ''
+  );
+}
+
+/**
+ * A fingerprint of THIS session, stable across the many invocations one agent
+ * session makes: AGENTCOMM_SESSION, else the terminal session id, else a
+ * STICKY fingerprint remembered for this process tree (issue #157 — deriving
+ * it from one fixed ancestor made it drift whenever a wrapper process added a
+ * level, silently moving the agent to a different, empty mailbox). Suffixes
+ * derived aliases and is recorded in registrations, so tooling can tell
+ * "stale me" from "someone else".
+ */
+export async function sessionHash(): Promise<string> {
+  if (sessionHashMemo !== undefined) return sessionHashMemo;
+  const pinned = pinnedSession();
+  if (pinned) {
+    sessionHashMemo = createHash('sha1').update(pinned).digest('hex').slice(0, 12);
+    return sessionHashMemo;
   }
-  sessionHashMemo = createHash('sha1').update(session).digest('hex').slice(0, 12);
+  sessionHashMemo = await stickySession(async () => {
+    try {
+      return 'gppid:' + (await execFileP('ps', ['-o', 'ppid=', '-p', String(process.ppid)])).stdout.trim();
+    } catch {
+      return 'ppid:' + String(process.ppid);
+    }
+  });
   return sessionHashMemo;
 }
 

--- a/src/session.ts
+++ b/src/session.ts
@@ -1,0 +1,183 @@
+/**
+ * Sticky session identity (issue #157).
+ *
+ * The session fingerprint suffixes the derived alias, so it decides WHICH
+ * mailbox a bare command reads. Deriving it fresh from one fixed ancestor
+ * ("the grandparent pid") made it drift: the same session invokes the CLI
+ * sometimes as a direct child, sometimes under `sh -c`, sometimes from a hook
+ * or a `timeout`/background wrapper, and every extra process layer shifted
+ * which pid "the grandparent" named. A drifted fingerprint is a DIFFERENT,
+ * empty mailbox — mail keeps arriving at the old one, `inbox` prints `[]`, and
+ * nothing about that looks wrong from the read side.
+ *
+ * The fix is to stop re-deriving and start remembering. The first invocation
+ * of a session writes a small state file recording its fingerprint plus the
+ * nearest few ancestor pids (its "anchors"); later invocations from anywhere
+ * in that process tree recognise a shared anchor and adopt the SAME
+ * fingerprint, however deep they happen to run. The file also carries the
+ * alias last used, so a change is announced instead of silently splitting.
+ */
+import { execFile } from 'node:child_process';
+import { promises as fs } from 'node:fs';
+import { createHash, randomUUID } from 'node:crypto';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+/** How long a recorded session stays adoptable. */
+const TTL_MS = Number(process.env.AGENTCOMM_SESSION_TTL_MS ?? 12 * 3600_000);
+/** How long its file survives at all (opportunistic pruning). */
+const PRUNE_MS = 4 * TTL_MS;
+/**
+ * How far up the process tree to anchor. Deep enough to survive a couple of
+ * wrapper processes (`sh -c`, `timeout`, a hook shell), shallow enough that
+ * the anchors stay inside one agent session rather than reaching the terminal
+ * or the desktop app every session on the machine shares.
+ */
+const ANCHOR_DEPTH = 3;
+
+export interface Anchor {
+  pid: number;
+  /** argv[0]/comm of that pid — guards against a recycled pid matching. */
+  comm: string;
+}
+
+export interface SessionState {
+  session: string;
+  /** Last alias a bare (derived) command acted as — the drift check. */
+  alias?: string;
+  updatedAt: string;
+  anchors: Anchor[];
+}
+
+export function stateDir(): string {
+  return (
+    process.env.AGENTCOMM_STATE_DIR ??
+    path.join(process.env.XDG_CACHE_HOME ?? path.join(os.homedir(), '.cache'), 'agentcomm', 'sessions')
+  );
+}
+
+/** One `ps` call, then walk: the nearest `depth` ancestors of this process. */
+export async function ancestry(depth = ANCHOR_DEPTH): Promise<Anchor[]> {
+  let table: string;
+  try {
+    table = await new Promise<string>((resolve, reject) =>
+      execFile('ps', ['-Ao', 'pid=,ppid=,comm='], { maxBuffer: 8 * 1024 * 1024 }, (err, out) =>
+        err ? reject(err) : resolve(out),
+      ),
+    );
+  } catch {
+    return [];
+  }
+  const tree = new Map<number, { ppid: number; comm: string }>();
+  for (const line of table.split('\n')) {
+    // "  1234   5678 /usr/bin/some command" — comm is the remainder, spaces and all
+    const m = /^\s*(\d+)\s+(\d+)\s+(.*)$/.exec(line);
+    if (m) tree.set(Number(m[1]), { ppid: Number(m[2]), comm: m[3]!.trim() });
+  }
+  const out: Anchor[] = [];
+  let pid = process.ppid;
+  while (out.length < depth && pid > 1) {
+    const node = tree.get(pid);
+    if (!node) break;
+    out.push({ pid, comm: node.comm });
+    pid = node.ppid;
+  }
+  return out;
+}
+
+const sameAnchor = (a: Anchor, b: Anchor): boolean => a.pid === b.pid && a.comm === b.comm;
+
+async function readStates(): Promise<{ file: string; state: SessionState }[]> {
+  const dir = stateDir();
+  let names: string[];
+  try {
+    names = await fs.readdir(dir);
+  } catch {
+    return [];
+  }
+  const out: { file: string; state: SessionState }[] = [];
+  for (const name of names) {
+    if (!name.endsWith('.json')) continue;
+    const file = path.join(dir, name);
+    try {
+      const state = JSON.parse(await fs.readFile(file, 'utf8')) as SessionState;
+      const age = Date.now() - Date.parse(state.updatedAt);
+      if (!(age >= 0)) continue; // unparseable timestamp
+      if (age > PRUNE_MS) {
+        await fs.rm(file, { force: true }).catch(() => {});
+        continue;
+      }
+      if (state.session && Array.isArray(state.anchors)) out.push({ file, state });
+    } catch {
+      /* half-written or foreign file — ignore */
+    }
+  }
+  return out;
+}
+
+async function writeState(state: SessionState): Promise<void> {
+  const dir = stateDir();
+  const file = path.join(dir, `${state.session}.json`);
+  const tmp = path.join(dir, `.${state.session}.${randomUUID().slice(0, 8)}`);
+  try {
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(tmp, JSON.stringify(state));
+    await fs.rename(tmp, file); // atomic replace — a concurrent reader sees one or the other
+  } catch {
+    await fs.rm(tmp, { force: true }).catch(() => {});
+    /* state is an optimization: never fail a command over it */
+  }
+}
+
+/** Merge new anchors into the recorded ones, newest first, bounded. */
+const mergeAnchors = (recorded: Anchor[], seen: Anchor[]): Anchor[] =>
+  [...seen, ...recorded.filter((r) => !seen.some((s) => sameAnchor(r, s)))].slice(0, ANCHOR_DEPTH * 2);
+
+/**
+ * The session fingerprint for THIS process: adopt the one recorded for a
+ * shared ancestor when there is one, else record a new one. `fallback`
+ * supplies the seed for a brand-new session (the historical derivation), so
+ * behavior is unchanged the very first time a session is seen.
+ */
+export async function stickySession(fallback: () => Promise<string>): Promise<string> {
+  const anchors = await ancestry();
+  if (anchors.length === 0) return hash(await fallback()); // no process table — old behavior
+
+  const fresh = (await readStates()).filter((s) => Date.now() - Date.parse(s.state.updatedAt) <= TTL_MS);
+  const match = fresh.find((s) => s.state.anchors.some((a) => anchors.some((mine) => sameAnchor(a, mine))));
+  if (match) {
+    await writeState({
+      ...match.state,
+      updatedAt: new Date().toISOString(),
+      anchors: mergeAnchors(match.state.anchors, anchors),
+    });
+    return match.state.session;
+  }
+
+  const session = hash(await fallback());
+  await writeState({ session, updatedAt: new Date().toISOString(), anchors });
+  return session;
+}
+
+/**
+ * Record the alias a bare command is acting as, and report the DIFFERENT one
+ * this session used before, if any. That prior name is where the mail is —
+ * the caller says so on stderr rather than letting an empty inbox pass for
+ * "no mail".
+ */
+export async function recordAlias(session: string, alias: string): Promise<string | null> {
+  const anchors = await ancestry();
+  const entry = (await readStates()).find((s) => s.state.session === session);
+  const previous = entry?.state.alias && entry.state.alias !== alias ? entry.state.alias : null;
+  await writeState({
+    session,
+    alias,
+    updatedAt: new Date().toISOString(),
+    anchors: mergeAnchors(entry?.state.anchors ?? [], anchors),
+  });
+  return previous;
+}
+
+function hash(seed: string): string {
+  return createHash('sha1').update(seed).digest('hex').slice(0, 12);
+}

--- a/test/session-sticky.e2e.test.ts
+++ b/test/session-sticky.e2e.test.ts
@@ -1,0 +1,128 @@
+/**
+ * e2e for the sticky session fingerprint (issue #157).
+ *
+ * The alias suffix decides WHICH mailbox a bare command reads. Deriving it
+ * from one fixed ancestor made it drift the moment a wrapper process added a
+ * level — the agent silently moved to a different, empty mailbox while mail
+ * kept arriving at the old one. These tests run the CLI at DIFFERENT process
+ * depths from one "session" (this test process, the shared ancestor) and
+ * assert every depth lands on the same alias.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { promises as fs } from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { createRequire } from 'node:module';
+import { spawn, execFileSync } from 'node:child_process';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const cli = path.join(here, '..', 'src', 'cli.ts');
+const tsx = pathToFileURL(createRequire(import.meta.url).resolve('tsx')).href;
+
+const tmpRoots: string[] = [];
+async function mkTmp(): Promise<string> {
+  const dir = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), 'agentcomm-sticky-')));
+  tmpRoots.push(dir);
+  return dir;
+}
+afterEach(async () => {
+  for (const dir of tmpRoots.splice(0)) await fs.rm(dir, { recursive: true, force: true });
+});
+
+interface Run {
+  code: number;
+  stdout: string;
+  stderr: string;
+}
+
+/**
+ * Run the CLI with NO pinned session, so the sticky path is exercised.
+ * `depth` extra `sh -c` wrappers simulate what actually caused the drift:
+ * hooks, `timeout`, backgrounding — each one shifting "the grandparent".
+ */
+function run(args: string[], cwd: string, stateDir: string, depth = 0, extraEnv: Record<string, string> = {}): Promise<Run> {
+  const env: NodeJS.ProcessEnv = {
+    PATH: process.env.PATH,
+    HOME: process.env.HOME,
+    AGENTCOMM_BACKEND: `file://${path.join(cwd, '.bus')}`,
+    AGENTCOMM_NO_GIT_PROBE: '1',
+    AGENTCOMM_STATE_DIR: stateDir,
+    ...extraEnv,
+  };
+  const argv = [process.execPath, '--import', tsx, cli, ...args].map((a) => `'${a.replace(/'/g, `'\\''`)}'`).join(' ');
+  const [cmd, cmdArgs] =
+    depth === 0
+      ? [process.execPath, ['--import', tsx, cli, ...args]]
+      : ['sh', ['-c', 'sh -c '.repeat(depth - 1) + (depth > 1 ? `"${argv}"` : argv)]];
+  return new Promise((resolve, reject) => {
+    const child = spawn(cmd, cmdArgs, { stdio: ['ignore', 'pipe', 'pipe'], cwd, env });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (d) => (stdout += d.toString()));
+    child.stderr.on('data', (d) => (stderr += d.toString()));
+    child.on('error', reject);
+    child.on('exit', (code) => resolve({ code: code ?? -1, stdout, stderr }));
+  });
+}
+
+async function repo(): Promise<string> {
+  const dir = await mkTmp();
+  execFileSync('git', ['-C', dir, 'init', '-q']);
+  execFileSync('git', ['-C', dir, 'config', 'user.email', 'sticky@corp.example']);
+  return dir;
+}
+
+const aliasOf = (r: Run): string => /registered (\S+)/.exec(r.stdout)?.[1] ?? '';
+
+describe('sticky session identity (issue #157)', () => {
+  it('resolves the same alias however deep in the process tree the CLI runs', async () => {
+    const dir = await repo();
+    const state = await mkTmp();
+
+    const shallow = await run(['register'], dir, state, 0);
+    expect(shallow.code).toBe(0);
+    const alias = aliasOf(shallow);
+    expect(alias).toMatch(/^sticky-[0-9a-f]{4}$/);
+
+    // Same session, two extra process levels — the case that used to mint a
+    // brand-new (empty) mailbox.
+    const deep = await run(['register'], dir, state, 2);
+    expect(aliasOf(deep)).toBe(alias);
+
+    // and mail sent to the alias is readable from the deep invocation
+    await run(['send', alias, 'ping', '--as', 'someone-else'], dir, state, 0);
+    const inbox = await run(['inbox', '--json'], dir, state, 2);
+    const msgs = JSON.parse(inbox.stdout) as { body: string }[];
+    expect(msgs.map((m) => m.body)).toEqual(['ping']);
+  });
+
+  it('an explicitly pinned session still wins and never touches the state dir', async () => {
+    const dir = await repo();
+    const state = await mkTmp();
+    const r = await run(['register'], dir, state, 0, { AGENTCOMM_SESSION: 'pinned-session' });
+    expect(r.code).toBe(0);
+    expect(await fs.readdir(state)).toEqual([]);
+  });
+
+  it('an empty mailbox names the alias it read', async () => {
+    const dir = await repo();
+    const state = await mkTmp();
+    const r = await run(['inbox'], dir, state, 0);
+    expect(r.stdout).toMatch(/\(no messages for sticky-[0-9a-f]{4}\)/);
+  });
+
+  it('warns when the derived alias changes underneath a session', async () => {
+    const dir = await repo();
+    const state = await mkTmp();
+    const first = await run(['register'], dir, state, 0);
+    const alias = aliasOf(first);
+    expect(first.stderr).not.toMatch(/NOTE/);
+
+    // the git identity changes mid-session: same session, different alias
+    execFileSync('git', ['-C', dir, 'config', 'user.email', 'renamed@corp.example']);
+    const second = await run(['inbox'], dir, state, 0);
+    expect(second.stderr).toMatch(new RegExp(`previously acted as ${alias}`));
+    expect(second.stderr).toMatch(new RegExp(`--as ${alias}`));
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,4 +1,6 @@
 import { defineConfig } from 'vitest/config';
+import * as os from 'node:os';
+import * as path from 'node:path';
 
 export default defineConfig({
   test: {
@@ -12,6 +14,12 @@ export default defineConfig({
     // repo is on its own bus, so connect-time provisioning would rewrite our
     // committed harness wiring mid-run. Off by default; the suite that covers
     // provisioning turns it back on per spawn.
-    env: { AGENTCOMM_NO_AUTO_HOOKS: '1' },
+    // Sticky session state (issue #157) is a real file on disk; keep the
+    // suite out of the developer's own ~/.cache so a test run can never
+    // adopt — or clobber — the session identity of the agent running it.
+    env: {
+      AGENTCOMM_NO_AUTO_HOOKS: '1',
+      AGENTCOMM_STATE_DIR: path.join(os.tmpdir(), `agentcomm-test-sessions-${process.pid}`),
+    },
   },
 });


### PR DESCRIPTION
Closes #157.

The alias suffix decides *which* mailbox a bare command reads, and it was re-derived on every invocation from one fixed ancestor — the grandparent pid. Any extra process layer (a hook's `sh -c`, `timeout`, backgrounding) shifted which pid that named, so the fingerprint changed and the agent silently moved to a different, empty mailbox.

## What changed

- **`src/session.ts` (new)** — sticky session state. The first invocation records its fingerprint plus its nearest 3 ancestor pids (with their `comm`, so a recycled pid can't match) in `~/.cache/agentcomm/sessions/<id>.json`; later invocations that share any anchor adopt the same fingerprint. 12h TTL, atomic writes, `AGENTCOMM_STATE_DIR` override, and every failure path is a no-op — session state is an optimization, never a reason to fail a command.
- **`src/identity.ts`** — an explicitly pinned session (`AGENTCOMM_SESSION`, iTerm/tmux ids) still wins and never touches disk; otherwise the fingerprint comes from the sticky path, seeded by the historical derivation so a brand-new session is unchanged.
- **`src/hook-run.ts`** — hooks stop computing and pinning `AGENTCOMM_SESSION` for their CLI children. Both they and the agent's own commands share the harness process as an anchor, so they converge on one mailbox by construction instead of by a matching heuristic.
- **`src/cli.ts`** — a derived alias that changes underneath a session says so on stderr and names where the mail is (`--as <previous>`); an empty read names the mailbox it read: `(no messages for X)`.

## Tests

`test/session-sticky.e2e.test.ts` runs the CLI at different process depths from one session and asserts they resolve the same alias and read the same mail; plus the pinned-session bypass, the empty-mailbox naming, and the drift notice. Full suite green (266 passed).