### PR TITLE
fix: deliver mail before consuming it (#158)

### DIFF
--- a/src/bus.ts
+++ b/src/bus.ts
@@ -123,45 +123,73 @@ export class Bus {
 
   // ── receiving ───────────────────────────────────────────────────────────
 
-  /** Consume: read all undelivered messages for `recipient`, archive under read/. */
-  async inbox(recipient: string): Promise<Message[]> {
+  /**
+   * Consume: read all undelivered messages for `recipient`, hand them to
+   * `deliver`, and only then archive under read/.
+   *
+   * The order is the contract (issue #158). Archiving as we read meant a
+   * command that died mid-flight — a harness timeout, a Ctrl-C, a broken pipe
+   * — left messages consumed AND undelivered: unrecoverable loss on the
+   * normal path. Delivering first makes the worst case a duplicate: whatever
+   * `deliver` accepted is out, and anything not archived is simply still
+   * pending. `deliver` must not resolve until the messages are durably in the
+   * caller's hands (the CLI waits for stdout to flush).
+   */
+  async inbox(
+    recipient: string,
+    opts: {
+      /** Hand the messages to the caller. Must resolve only once they are durably received. */
+      deliver?: (messages: Message[]) => Promise<void> | void;
+      /** Delivered but still pending (archiving failed) — they will arrive again. */
+      onUnarchived?: (keys: string[]) => void;
+    } = {},
+  ): Promise<Message[]> {
     assertName(recipient);
-    const keys = await this.backend.list(inboxPrefix(recipient));
-    const out: Message[] = [];
-    for (const key of keys) {
-      if (!key.endsWith('.json')) continue;
-      let msg: Message;
-      try {
-        msg = decode<Message>(await this.backend.get(key));
-      } catch {
-        continue; // skip a key that vanished (raced consumer) or is corrupt
-      }
-      // Archive (don't hard-delete): preserve the audit trail under read/.
-      const dst = readKeyFromInboxKey(key);
-      try {
-        await this.backend.move(key, dst);
-      } catch {
-        continue; // another consumer claimed it first
-      }
-      out.push(msg);
+    const pending = await this.pending(recipient);
+    const messages = pending.map((p) => p.message);
+    await opts.deliver?.(messages);
+    if (messages.length > 0) {
+      const failed = await this.archive(pending.map((p) => p.key));
+      if (failed.length > 0) opts.onUnarchived?.(failed);
     }
-    return out;
+    return messages;
   }
 
   /** Non-consuming: read undelivered messages for `recipient` without archiving. */
   async peek(recipient: string): Promise<Message[]> {
+    return (await this.pending(recipient)).map((p) => p.message);
+  }
+
+  /** Undelivered messages for `recipient`, each with the inbox key holding it. */
+  async pending(recipient: string): Promise<{ key: string; message: Message }[]> {
     assertName(recipient);
-    const keys = await this.backend.list(inboxPrefix(recipient));
-    const out: Message[] = [];
-    for (const key of keys) {
+    const out: { key: string; message: Message }[] = [];
+    for (const key of await this.backend.list(inboxPrefix(recipient))) {
       if (!key.endsWith('.json')) continue;
       try {
-        out.push(decode<Message>(await this.backend.get(key)));
+        out.push({ key, message: decode<Message>(await this.backend.get(key)) });
       } catch {
-        continue;
+        continue; // vanished (raced consumer) or corrupt
       }
     }
     return out;
+  }
+
+  /**
+   * Archive (don't hard-delete) inbox keys under read/, preserving the audit
+   * trail. Returns the keys that could NOT be archived — a raced consumer, or
+   * a store that went away mid-run; they stay pending and re-deliver.
+   */
+  async archive(keys: string[]): Promise<string[]> {
+    const failed: string[] = [];
+    for (const key of keys) {
+      try {
+        await this.backend.move(key, readKeyFromInboxKey(key));
+      } catch {
+        failed.push(key);
+      }
+    }
+    return failed;
   }
 
   /**

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1086,17 +1086,27 @@ async function cmdBroadcast(
   return 0;
 }
 
+/**
+ * Consume the mailbox — print first, archive after (issue #158). An `inbox`
+ * that dies mid-flight used to leave messages consumed AND unprinted; now the
+ * worst case is a message that stays pending and arrives twice.
+ */
 async function cmdInbox(bus: Bus, cfg: ResolvedConfig): Promise<number> {
   const me = await resolveAgent(cfg);
-  const messages = await bus.inbox(me);
-  printMessages(messages, cfg, me);
+  await bus.inbox(me, {
+    deliver: (messages) => printMessages(messages, cfg, me),
+    onUnarchived: (keys) =>
+      process.stderr.write(
+        `agentcomm: ${keys.length} message(s) were delivered but could not be archived — they stay pending and will arrive again.\n`,
+      ),
+  });
   return 0;
 }
 
 async function cmdPeek(bus: Bus, cfg: ResolvedConfig): Promise<number> {
   const me = await resolveAgent(cfg);
   const messages = await bus.peek(me);
-  printMessages(messages, cfg, me);
+  await printMessages(messages, cfg, me);
   return 0;
 }
 
@@ -1108,7 +1118,7 @@ async function cmdWait(bus: Bus, cfg: ResolvedConfig, timeoutMs: number): Promis
     else process.stderr.write(`wait: timed out after ${timeoutMs}ms\n`);
     return 2; // timeout
   }
-  printMessages(messages, cfg, me);
+  await printMessages(messages, cfg, me);
   return 0; // delivered
 }
 
@@ -1278,22 +1288,33 @@ async function loadBackendPlugins(): Promise<void> {
 
 // ── helpers ─────────────────────────────────────────────────────────────────
 
-function printMessages(messages: Message[], cfg: ResolvedConfig, recipient?: string): void {
-  if (cfg.json) {
-    emit(messages);
-    return;
-  }
+/**
+ * Write to stdout and resolve only once the bytes are handed to the OS.
+ * `inbox` archives what it has delivered, so "delivered" has to mean out of
+ * this process, not queued inside it (issue #158).
+ */
+function writeOut(text: string): Promise<void> {
+  return new Promise((resolve) => {
+    process.stdout.write(text, () => resolve());
+  });
+}
+
+async function printMessages(messages: Message[], cfg: ResolvedConfig, recipient?: string): Promise<void> {
+  if (cfg.json) return writeOut(JSON.stringify(messages, null, 2) + '\n');
   if (messages.length === 0) {
     // Name the mailbox that was read: "no messages" reads as "no mail
     // anywhere", which is exactly how a drifted alias hides (issue #157).
-    process.stdout.write(recipient ? `(no messages for ${recipient})\n` : '(no messages)\n');
-    return;
+    return writeOut(recipient ? `(no messages for ${recipient})\n` : '(no messages)\n');
   }
-  for (const m of messages) {
-    const subj = m.subject ? ` [${m.subject}]` : '';
-    const thr = m.thread ? ` (thread ${m.thread})` : '';
-    process.stdout.write(`from ${m.from} at ${m.ts}${subj}${thr}\n  ${m.body}\n`);
-  }
+  return writeOut(
+    messages
+      .map((m) => {
+        const subj = m.subject ? ` [${m.subject}]` : '';
+        const thr = m.thread ? ` (thread ${m.thread})` : '';
+        return `from ${m.from} at ${m.ts}${subj}${thr}\n  ${m.body}\n`;
+      })
+      .join(''),
+  );
 }
 
 let derivedIdentity: string | null | undefined; // memo: undefined = not derived yet

--- a/test/bus.test.ts
+++ b/test/bus.test.ts
@@ -187,3 +187,80 @@ describe('status precedence: explicit wins while fresh, task refreshes when stal
     await backend.close?.();
   });
 });
+
+/**
+ * Delivery before consumption (issue #158). Archiving as we read meant an
+ * `inbox` that died mid-flight — a harness timeout, a Ctrl-C — left messages
+ * consumed AND undelivered. These pin the order, and the failure mode when
+ * the archive step is the thing that breaks.
+ */
+describe('inbox delivers before it consumes (issue #158)', () => {
+  /** A backend that records op order and can be told to fail every move. */
+  class Recording implements Backend {
+    readonly ops: string[] = [];
+    breakMove = false;
+    constructor(private readonly inner: Backend) {}
+    put(key: string, data: Buffer): Promise<void> {
+      return this.inner.put(key, data);
+    }
+    get(key: string): Promise<Buffer> {
+      return this.inner.get(key);
+    }
+    list(prefix: string): Promise<string[]> {
+      return this.inner.list(prefix);
+    }
+    delete(key: string): Promise<void> {
+      return this.inner.delete(key);
+    }
+    exists(key: string): Promise<boolean> {
+      return this.inner.exists(key);
+    }
+    async move(src: string, dst: string): Promise<void> {
+      this.ops.push(`move ${src}`);
+      if (this.breakMove) throw new Error('store went away');
+      return this.inner.move(src, dst);
+    }
+  }
+
+  const busWith = async (): Promise<{ bus: Bus; backend: Recording }> => {
+    const backend = new Recording(new LocalBackend(await mkTmp()));
+    const bus = new Bus(backend);
+    for (const body of ['one', 'two']) await bus.send({ from: 'alice', to: 'bob', body });
+    return { bus, backend };
+  };
+
+  it('hands every message to the caller before archiving any of them', async () => {
+    const { bus, backend } = await busWith();
+    const got = await bus.inbox('bob', {
+      deliver: (messages) => {
+        backend.ops.push(`deliver ${messages.length}`);
+      },
+    });
+    expect(got.map((m) => m.body)).toEqual(['one', 'two']);
+    expect(backend.ops[0]).toBe('deliver 2');
+    expect(backend.ops.filter((o) => o.startsWith('move'))).toHaveLength(2);
+  });
+
+  it('a delivery that throws consumes nothing — the mail is still there', async () => {
+    const { bus, backend } = await busWith();
+    await expect(
+      bus.inbox('bob', {
+        deliver: () => {
+          throw new Error('pipe closed');
+        },
+      }),
+    ).rejects.toThrow(/pipe closed/);
+    expect(backend.ops).toHaveLength(0);
+    expect((await bus.peek('bob')).map((m) => m.body)).toEqual(['one', 'two']);
+  });
+
+  it('an archive that fails re-delivers rather than losing: reported, still pending', async () => {
+    const { bus, backend } = await busWith();
+    backend.breakMove = true;
+    const unarchived: string[] = [];
+    const got = await bus.inbox('bob', { onUnarchived: (keys) => unarchived.push(...keys) });
+    expect(got.map((m) => m.body)).toEqual(['one', 'two']);
+    expect(unarchived).toHaveLength(2);
+    expect((await bus.peek('bob')).map((m) => m.body)).toEqual(['one', 'two']);
+  });
+});


### PR DESCRIPTION
Closes #158.

`inbox` read and archived one message at a time and only returned once the whole loop finished, so anything archived before the command died — a harness timeout, a Ctrl-C, a broken pipe — was consumed **and** never delivered. Unrecoverable loss on the normal path.

## What changed

- **`src/bus.ts`** — `inbox` now reads everything (`pending()`), hands it to a `deliver` callback, and archives (`archive()`) only after that callback resolves. `peek` is the same read without the archive step. Whatever fails to archive is reported via `onUnarchived` and stays pending.
- **`src/cli.ts`** — `printMessages` builds one payload and waits for stdout to be flushed to the OS before returning, so "delivered" means out of the process, not queued inside it. Unarchived messages get an explicit stderr note.

The worst case is now a duplicate (a pending message arrives twice) instead of a hole.

## Tests

`test/bus.test.ts` pins the order against a recording backend: delivery happens before any `move`; a delivery that throws consumes nothing; an archive that fails leaves the mail pending and reports it. Full suite green (269 passed).