### PR TITLE
feat: show whether a recipient is actually reading (#162)

### DIFF
--- a/src/backends/git.ts
+++ b/src/backends/git.ts
@@ -244,19 +244,26 @@ export class GitBackend implements Backend, Batchable, Claimable, Snapshottable 
   }
 
   /**
-   * One fetch, then every body read from local objects at that tip — the
-   * daemon's warm path. Key-by-key `get` would pay a fetch per key.
+   * One fetch, then bodies read from local objects at that tip — the daemon's
+   * warm path. Key-by-key `get` would pay a fetch per key. Listing names is
+   * cheap (`ls-tree`); reading blobs is not, so `opts.bodies` picks which
+   * ones are worth the batch (issue #167).
    */
-  async snapshot(prefix: string): Promise<Map<string, Buffer>> {
+  async snapshot(
+    prefix: string,
+    opts?: { bodies?: (key: string) => boolean },
+  ): Promise<{ keys: string[]; bodies: Map<string, Buffer> }> {
     const out = new Map<string, Buffer>();
     const tip = await this.tip();
-    if (tip === null) return out;
+    if (tip === null) return { keys: [], bodies: out };
     const full = this.k(prefix);
-    const names = (await this.git(['ls-tree', '-r', '--name-only', '-z', tip]))
+    const all = (await this.git(['ls-tree', '-r', '--name-only', '-z', tip]))
       .toString('utf8')
       .split('\0')
       .filter((p) => p.length > 0 && p.startsWith(full) && p.startsWith(this.keyPrefix));
-    if (names.length === 0) return out;
+    const keys = all.map((p) => p.slice(this.keyPrefix.length));
+    const names = opts?.bodies ? all.filter((p) => opts.bodies!(p.slice(this.keyPrefix.length))) : all;
+    if (names.length === 0) return { keys, bodies: out };
     const batch = await this.git(['cat-file', '--batch'], {
       input: Buffer.from(names.map((p) => `${tip}:${p}`).join('\n') + '\n'),
     });
@@ -272,7 +279,7 @@ export class GitBackend implements Backend, Batchable, Claimable, Snapshottable 
       out.set(p.slice(this.keyPrefix.length), Buffer.from(batch.subarray(off, off + size)));
       off += size + 1; // body + trailing newline
     }
-    return out;
+    return { keys, bodies: out };
   }
 
   async list(prefix: string): Promise<string[]> {

--- a/src/bus.ts
+++ b/src/bus.ts
@@ -176,6 +176,29 @@ export class Bus {
   }
 
   /**
+   * Clear mail that has already been read (issue #160). `peek` shows messages
+   * without consuming and `inbox` consumes what it shows — with only those
+   * two, an agent that read its mail the non-destructive way could never mark
+   * it read, so the unread count (and the stop guard behind it) stayed stuck
+   * at N forever. Acking works off the KEYS: no body is re-fetched, and ids
+   * that are not pending are reported rather than silently ignored.
+   */
+  async ack(
+    recipient: string,
+    ids: string[] | 'all',
+  ): Promise<{ acked: string[]; unknown: string[]; failed: string[] }> {
+    assertName(recipient);
+    const keys = (await this.backend.list(inboxPrefix(recipient))).filter((k) => k.endsWith('.json'));
+    const byId = new Map(keys.map((key) => [messageIdFromKey(key), key] as const));
+    const wanted = ids === 'all' ? [...byId.keys()] : ids;
+    const unknown = wanted.filter((id) => !byId.has(id));
+    const targets = wanted.filter((id) => byId.has(id));
+    const failedKeys = await this.archive(targets.map((id) => byId.get(id)!));
+    const failed = targets.filter((id) => failedKeys.includes(byId.get(id)!));
+    return { acked: targets.filter((id) => !failed.includes(id)), unknown, failed };
+  }
+
+  /**
    * Archive (don't hard-delete) inbox keys under read/, preserving the audit
    * trail. Returns the keys that could NOT be archived — a raced consumer, or
    * a store that went away mid-run; they stay pending and re-deliver.
@@ -263,6 +286,10 @@ function inboxKey(recipient: string, seq: string, id: string): string {
 }
 function readKeyFromInboxKey(inboxKey: string): string {
   return 'read/' + inboxKey.slice('inbox/'.length);
+}
+/** The message id a key carries: inbox/<to>/<seq>_<id>.json — no read needed. */
+function messageIdFromKey(key: string): string {
+  return key.slice(key.lastIndexOf('_') + 1).replace(/\.json$/, '');
 }
 
 // ── sequence generation ─────────────────────────────────────────────────────

--- a/src/bus.ts
+++ b/src/bus.ts
@@ -57,6 +57,7 @@ export class Bus {
       name,
       registeredAt: existing?.registeredAt ?? now,
       lastSeen: now,
+      ...(existing?.lastRead ? { lastRead: existing.lastRead } : {}),
       ...(session ? { session } : {}),
       ...(nextStatus ? { status: nextStatus, statusAuto: nextAuto, statusAt: nextStatusAt } : {}),
     };
@@ -80,6 +81,45 @@ export class Bus {
     }
     out.sort((a, b) => a.name.localeCompare(b.name));
     return out;
+  }
+
+  /**
+   * Record that `name` consumed its mailbox. A send reports success whether
+   * or not anyone is reading; this is the other half of that story, and it
+   * costs one write on a command agents run a handful of times a session.
+   *
+   * Only an EXISTING registration is stamped. Reading must not create one:
+   * registrations are never purged, so a one-off `inbox --as someone` would
+   * put a permanent ghost on the roster. An unregistered reader simply has
+   * no read history — which is exactly what `send` reports about it.
+   */
+  async markRead(name: string): Promise<void> {
+    assertName(name);
+    const existing = await this.tryGetAgent(name);
+    if (!existing) return;
+    const now = new Date().toISOString();
+    await this.backend.put(agentKey(name), encode({ ...existing, lastSeen: now, lastRead: now }));
+  }
+
+  /**
+   * Undelivered message count per recipient, from KEYS alone — one list, no
+   * bodies. Mailboxes with no registration count too: mail addressed to a
+   * name nobody is reading is precisely what needs surfacing.
+   */
+  async unreadCounts(): Promise<Record<string, number>> {
+    const counts: Record<string, number> = {};
+    for (const key of await this.backend.list('inbox/')) {
+      if (!key.endsWith('.json')) continue;
+      const recipient = key.slice('inbox/'.length, key.indexOf('/', 'inbox/'.length));
+      if (recipient) counts[recipient] = (counts[recipient] ?? 0) + 1;
+    }
+    return counts;
+  }
+
+  /** Undelivered count for one recipient — the cheap pre-send check. */
+  async unread(recipient: string): Promise<number> {
+    assertName(recipient);
+    return (await this.backend.list(inboxPrefix(recipient))).filter((k) => k.endsWith('.json')).length;
   }
 
   private async tryGetAgent(name: string): Promise<AgentRecord | null> {
@@ -345,4 +385,11 @@ export interface AgentRecord {
   statusAuto?: boolean;
   /** ISO 8601 time the status was set — bounds how long an explicit one stays sticky. */
   statusAt?: string;
+  /**
+   * ISO 8601 time this agent last CONSUMED its mailbox (issue #162). `sent`
+   * only ever meant "queued"; this is what makes "and someone read it"
+   * answerable — a recipient with mail piling up and no read for hours is
+   * worth surfacing to whoever is sending it work.
+   */
+  lastRead?: string;
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,7 +8,7 @@ import { parseArgs, resolveConfig, type ParsedFlags, type ResolvedConfig } from 
 import type { Backend, Message } from './types.js';
 import { fileURLToPath } from 'node:url';
 import { deriveIdentity, pinnedSession, sessionHash } from './identity.js';
-import { recordAlias } from './session.js';
+import { leaseMailbox, recordAlias, releaseMailbox } from './session.js';
 import { INSTALL_COMMAND } from './update-check.js';
 import {
   EVENTS_PREFIX,
@@ -326,8 +326,33 @@ async function main(argv: string[]): Promise<number> {
         return 1;
     }
   } finally {
+    if (leasedAlias) await releaseMailbox(leasedAlias).catch(() => {});
     await backend.close?.();
   }
+}
+
+let leasedAlias: string | null = null;
+
+/**
+ * Announce that this process is acting as `me`, and say so when ANOTHER live
+ * process of this session is doing the same (issue #161). A subagent inherits
+ * its parent's identity, so `agentcomm inbox` from one drains the mailbox its
+ * parent is waiting on — silently, because the alias looks right. Identity
+ * stays per-session by design (a session is a mailbox); the fix is that
+ * sharing one stops being invisible.
+ */
+async function guardMailbox(me: string, command: string, kind: 'consuming' | 'status' | 'quiet'): Promise<void> {
+  const others = await leaseMailbox(me, command).catch(() => [] as Awaited<ReturnType<typeof leaseMailbox>>);
+  leasedAlias = me;
+  if (kind === 'quiet' || others.length === 0) return;
+  const who = others.map((o) => `pid ${o.pid} (\`agentcomm ${o.command}\`, since ${o.since})`).join(', ');
+  process.stderr.write(
+    kind === 'consuming'
+      ? `agentcomm: WARNING — another live process of this session is acting as "${me}": ${who}. ` +
+          `Reads CONSUME, so this takes mail addressed to it. If you are a subagent, use a mailbox of your own: --as ${me}-<role>.\n`
+      : `agentcomm: WARNING — another live process of this session is acting as "${me}": ${who}. ` +
+          `Your status replaces its line on the shared roster; register under your own --as if you are a separate actor.\n`,
+  );
 }
 
 // ── commands ────────────────────────────────────────────────────────────────
@@ -708,7 +733,9 @@ This repo has a message bus for AI agents. When working here:
   the user; otherwise stay on your task.
 - If your harness has subagents, prefer a background listener subagent for
   \`wait\`/inbox management (one actor per mailbox — it owns the alias or
-  uses \`--as <you>-bus\`); keep quick sends inline.
+  uses \`--as <you>-bus\`); keep quick sends inline. A subagent derives the
+  SAME alias as its parent, so a bare \`inbox\` there drains the parent's
+  mail; the CLI warns when two live processes share a mailbox — heed it.
 `;
 
 async function cmdInit(bus: Bus, cfg: ResolvedConfig, requestedHarness?: string): Promise<number> {
@@ -949,6 +976,7 @@ async function cmdRegister(
   statusAuto?: boolean,
 ): Promise<number> {
   const me = await resolveAgent(cfg);
+  await guardMailbox(me, 'register', status !== undefined ? 'status' : 'quiet');
   const record = await registerWithCollisionCheck(bus, me, status, statusAuto);
   if (cfg.json) emit(record);
   else process.stdout.write(`registered ${record.name}\n`);
@@ -1108,6 +1136,7 @@ async function cmdBroadcast(
  */
 async function cmdInbox(bus: Bus, cfg: ResolvedConfig): Promise<number> {
   const me = await resolveAgent(cfg);
+  await guardMailbox(me, 'inbox', 'consuming');
   await bus.inbox(me, {
     deliver: (messages) => printMessages(messages, cfg, me),
     onUnarchived: (keys) =>
@@ -1120,6 +1149,7 @@ async function cmdInbox(bus: Bus, cfg: ResolvedConfig): Promise<number> {
 
 async function cmdPeek(bus: Bus, cfg: ResolvedConfig): Promise<number> {
   const me = await resolveAgent(cfg);
+  await guardMailbox(me, 'peek', 'quiet'); // reading is harmless; hold the lease so a concurrent consumer sees us
   const messages = await bus.peek(me);
   await printMessages(messages, cfg, me);
   // peek leaves the mail unread by design; say how to clear it once acted on,
@@ -1138,6 +1168,7 @@ async function cmdPeek(bus: Bus, cfg: ResolvedConfig): Promise<number> {
  */
 async function cmdAck(bus: Bus, cfg: ResolvedConfig, all: boolean, ids: string[]): Promise<number> {
   const me = await resolveAgent(cfg);
+  await guardMailbox(me, 'ack', 'consuming');
   if (!all && ids.length === 0) {
     fail('ack requires message ids (from `peek`/`inbox --json`) or --all: agentcomm ack <id…> | agentcomm ack --all');
   }
@@ -1161,6 +1192,10 @@ async function cmdAck(bus: Bus, cfg: ResolvedConfig, all: boolean, ids: string[]
 
 async function cmdWait(bus: Bus, cfg: ResolvedConfig, timeoutMs: number): Promise<number> {
   const me = await resolveAgent(cfg);
+  // wait is non-consuming, but it HOLDS the mailbox for its whole timeout —
+  // the listener pattern. Leasing here is what lets a concurrent `inbox`
+  // report that it is about to drain someone's mail (issue #161).
+  await guardMailbox(me, 'wait', 'quiet');
   const messages = await bus.wait(me, timeoutMs);
   if (messages.length === 0) {
     if (cfg.json) emit([]);
@@ -1173,6 +1208,7 @@ async function cmdWait(bus: Bus, cfg: ResolvedConfig, timeoutMs: number): Promis
 
 async function cmdClaim(bus: Bus, cfg: ResolvedConfig, queue: string | undefined): Promise<number> {
   const me = await resolveAgent(cfg);
+  await guardMailbox(me, 'claim', 'quiet'); // a shared queue is MEANT to have many claimers
   if (!queue) {
     fail('claim requires --queue <name>');
   }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -158,6 +158,10 @@ Env:
                              stderr)
   AGENTCOMM_DAEMON=1|0       Default all commands through / away from the daemon
   AGENTCOMM_POLL_MS          Daemon remote-poll interval (default 10000)
+  AGENTCOMM_MIRROR_HISTORY_MS  How much archive/telemetry history the daemon
+                             keeps warm (default 7d). Older keys stay listable
+                             and readable; their bodies just load on demand,
+                             so a poll costs what is hot, not all history
   AGENTCOMM_BACKEND_PLUGINS  comma/whitespace-separated module specifiers to
                              import before resolving --backend, so a
                              third-party package can register a new URI

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -58,10 +58,14 @@ Commands:
                            task-status, telemetry. Stdin JSON in, hook
                            JSON out, always exits 0
   register                 Register/heartbeat the calling agent (--as)
-  agents                   List registered agents
+  agents                   List registered agents — with each one's unread
+                           depth and how long ago it last consumed its mailbox
   network                  Situation report: who is on the bus and what
                            they're doing (active/idle + recent activity)
-  send <to> [body]         Send a message (body from arg or stdin)
+  send <to> [body]         Send a message (body from arg or stdin). Warns when
+                           the recipient is not reading: unread piling up, no
+                           consuming read in AGENTCOMM_STALE_READ_MS (6h), or
+                           no registration under that name at all
   broadcast [body]         Send to every registered agent except yourself
   inbox                    Consume undelivered messages (archived under read/) —
                            printed first, archived after, so an interrupted
@@ -158,6 +162,8 @@ Env:
                              stderr)
   AGENTCOMM_DAEMON=1|0       Default all commands through / away from the daemon
   AGENTCOMM_POLL_MS          Daemon remote-poll interval (default 10000)
+  AGENTCOMM_STALE_READ_MS    How long a recipient can go without consuming
+                             before \`send\` flags it (default 6h)
   AGENTCOMM_MIRROR_HISTORY_MS  How much archive/telemetry history the daemon
                              keeps warm (default 7d). Older keys stay listable
                              and readable; their bodies just load on demand,
@@ -986,9 +992,19 @@ async function cmdRegister(
 async function cmdAgents(bus: Bus, cfg: ResolvedConfig): Promise<number> {
   const list = await bus.agents();
   const mySession = await sessionHash();
+  // Who is actually CONSUMING (issue #162) — a roster of names says nothing
+  // about whether work routed to them is being picked up.
+  const unread = await bus.unreadCounts().catch(() => ({}) as Record<string, number>);
   const isActive = (a: { lastSeen: string }) => Date.now() - Date.parse(a.lastSeen) < 10 * 60_000;
   if (cfg.json) {
-    emit(list.map((a) => ({ ...a, thisSession: a.session === mySession, active: isActive(a) })));
+    emit(
+      list.map((a) => ({
+        ...a,
+        unread: unread[a.name] ?? 0,
+        thisSession: a.session === mySession,
+        active: isActive(a),
+      })),
+    );
   } else if (list.length === 0) {
     process.stdout.write('(no agents registered)\n');
   } else {
@@ -996,7 +1012,9 @@ async function cmdAgents(bus: Bus, cfg: ResolvedConfig): Promise<number> {
       const mine = a.session === mySession ? '  (this session)' : '';
       const live = isActive(a) ? '  · active' : '';
       const doing = a.status ? `  — ${a.status}` : '';
-      process.stdout.write(`${a.name}\tlast seen ${a.lastSeen}${live}${mine}${doing}\n`);
+      const waiting = unread[a.name] ? `  · ${unread[a.name]} unread` : '';
+      const read = a.lastRead ? `  · read ${relTime(a.lastRead)}` : unread[a.name] ? '  · never read' : '';
+      process.stdout.write(`${a.name}\tlast seen ${a.lastSeen}${live}${mine}${waiting}${read}${doing}\n`);
     }
   }
   return 0;
@@ -1026,16 +1044,27 @@ async function cmdNetwork(
 ): Promise<number> {
   const list = await bus.agents();
   const mySession = await sessionHash();
+  const unread = await bus.unreadCounts().catch(() => ({}) as Record<string, number>);
   const isActive = (a: { lastSeen: string }) => Date.now() - Date.parse(a.lastSeen) < 10 * 60_000;
   const active = list.filter(isActive).sort((a, b) => b.lastSeen.localeCompare(a.lastSeen));
   const idle = list.filter((a) => !isActive(a)).sort((a, b) => b.lastSeen.localeCompare(a.lastSeen));
   const recent = await recentMessages(backend, 5);
+  // Mail addressed to a name that never registered: queued forever, and
+  // invisible on a roster built from registrations alone (issue #162).
+  const unclaimed = Object.entries(unread).filter(([name]) => !list.some((a) => a.name === name));
 
   if (cfg.json) {
+    const withUnread = (a: (typeof list)[number], live: boolean) => ({
+      ...a,
+      unread: unread[a.name] ?? 0,
+      thisSession: a.session === mySession,
+      active: live,
+    });
     emit({
       bus: cfg.backendUri,
-      active: active.map((a) => ({ ...a, thisSession: a.session === mySession, active: true })),
-      idle: idle.map((a) => ({ ...a, thisSession: a.session === mySession, active: false })),
+      active: active.map((a) => withUnread(a, true)),
+      idle: idle.map((a) => withUnread(a, false)),
+      unclaimed: unclaimed.map(([name, count]) => ({ name, unread: count })),
       recent,
     });
     return 0;
@@ -1044,7 +1073,8 @@ async function cmdNetwork(
   const line = (a: (typeof list)[number]): string => {
     const mine = a.session === mySession ? ' (you)' : '';
     const doing = a.status ? a.status : '—';
-    return `  ${(a.name + mine).padEnd(24)} ${doing.padEnd(42).slice(0, 42)} ${relTime(a.lastSeen)}`;
+    const waiting = unread[a.name] ? ` ${unread[a.name]} unread` : '';
+    return `  ${(a.name + mine).padEnd(24)} ${doing.padEnd(42).slice(0, 42)} ${relTime(a.lastSeen)}${waiting}`;
   };
 
   process.stdout.write(`bus  ${cfg.backendUri}\n\n`);
@@ -1057,6 +1087,13 @@ async function cmdNetwork(
   }
   if (idle.length) {
     process.stdout.write(`idle (${idle.length})\n${idle.map(line).join('\n')}\n\n`);
+  }
+  if (unclaimed.length) {
+    process.stdout.write(
+      `unread for nobody (no registration under that name)\n${unclaimed
+        .map(([name, count]) => `  ${name.padEnd(24)} ${count} message(s) queued`)
+        .join('\n')}\n\n`,
+    );
   }
   if (recent.length) {
     process.stdout.write('recent\n');
@@ -1109,9 +1146,33 @@ async function cmdSend(
   }
   const body = rest.length > 1 ? rest.slice(1).join(' ') : await readStdin();
   const msg = await bus.send({ from: me, to, body, subject, thread });
-  if (cfg.json) emit(msg);
-  else process.stdout.write(`sent ${msg.id} → ${to}\n`);
+  // `sent` has only ever meant QUEUED. Say so when the evidence says nobody
+  // is picking it up (issue #162) — a recipient with mail stacking up and no
+  // read for hours is worth knowing about before you route work to it.
+  const delivery = await deliveryWarning(bus, to).catch(() => null);
+  if (cfg.json) emit({ ...msg, ...(delivery ? { warning: delivery } : {}) });
+  else process.stdout.write(`sent ${msg.id} → ${to}\n${delivery ? `agentcomm: warning — ${delivery}\n` : ''}`);
   return 0;
+}
+
+/** How stale a recipient's last read has to be before a send is worth flagging. */
+const STALE_READ_MS = Number(process.env.AGENTCOMM_STALE_READ_MS ?? 6 * 3600_000);
+
+/** Why this send may not reach anyone, or null when the recipient looks healthy. */
+async function deliveryWarning(bus: Bus, to: string): Promise<string | null> {
+  const record = (await bus.agents()).find((a) => a.name === to);
+  const unread = await bus.unread(to);
+  if (!record) {
+    return `${to} has never registered on this bus — nothing is known to be reading that mailbox (${unread} message(s) waiting).`;
+  }
+  if (unread <= 1) return null; // the one we just sent, or an empty box: normal
+  const read = record.lastRead ? Date.now() - Date.parse(record.lastRead) : null;
+  if (read !== null && read < STALE_READ_MS) return null;
+  return (
+    `${to} has ${unread} unread and ` +
+    (record.lastRead ? `has not consumed its mailbox since ${record.lastRead}` : 'has never consumed its mailbox') +
+    ` (last seen ${relTime(record.lastSeen)}).`
+  );
 }
 
 async function cmdBroadcast(
@@ -1137,6 +1198,7 @@ async function cmdBroadcast(
 async function cmdInbox(bus: Bus, cfg: ResolvedConfig): Promise<number> {
   const me = await resolveAgent(cfg);
   await guardMailbox(me, 'inbox', 'consuming');
+  await bus.markRead(me).catch(() => {}); // "someone is reading X" — see cmdSend (issue #162)
   await bus.inbox(me, {
     deliver: (messages) => printMessages(messages, cfg, me),
     onUnarchived: (keys) =>
@@ -1173,6 +1235,7 @@ async function cmdAck(bus: Bus, cfg: ResolvedConfig, all: boolean, ids: string[]
     fail('ack requires message ids (from `peek`/`inbox --json`) or --all: agentcomm ack <id…> | agentcomm ack --all');
   }
   const result = await bus.ack(me, all ? 'all' : ids);
+  await bus.markRead(me).catch(() => {});
   if (cfg.json) {
     await writeOut(JSON.stringify({ agent: me, ...result }, null, 2) + '\n');
     return result.unknown.length > 0 ? 1 : 0;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -31,6 +31,7 @@ Agent quickstart (if you are an AI agent):
   agentcomm inbox --json                              # consume instructions that may be waiting
   agentcomm network                                   # who else is here, what they're doing
   agentcomm send <to> "<body>"  ·  agentcomm wait     # coordinate — reply on the sender's --thread
+  agentcomm peek  ·  agentcomm ack --all              # read without consuming, then clear what you handled
   Re-check your inbox before reporting your task done.
   Full etiquette: agentcomm conventions · bus semantics: agentcomm describe
 
@@ -62,8 +63,13 @@ Commands:
                            they're doing (active/idle + recent activity)
   send <to> [body]         Send a message (body from arg or stdin)
   broadcast [body]         Send to every registered agent except yourself
-  inbox                    Consume undelivered messages (archived under read/)
+  inbox                    Consume undelivered messages (archived under read/) —
+                           printed first, archived after, so an interrupted
+                           read costs a duplicate, never a lost message
   peek                     Show undelivered messages without consuming
+  ack <id…> | --all        Clear mail you already read some other way (peek, a
+                           digest): archives it without re-fetching. Exit 1
+                           when an id is not pending for you
   wait                     Block until a message arrives (exit 0) or timeout (exit 2)
   claim                    Atomically dequeue one message from --queue (SQL backends only)
   emit                     Record a telemetry event (--type, --name, --ref,
@@ -130,6 +136,7 @@ Flags:
   --check                  install: report drift instead of writing (exit 1 when
                            the wiring is missing or older than this CLI)
   --uninstall              install: remove the wiring this command wrote
+  --all                    ack: clear every message pending for you
   --type <text>            emit/events: the event type (skill-ran, skill-outcome, …)
   --name <text>            emit/events: what the event is about (a skill/tool name)
   --ref <text>             emit/events: correlation handle (branch, PR#, run id)
@@ -296,6 +303,8 @@ async function main(argv: string[]): Promise<number> {
         return await cmdInbox(bus, cfg);
       case 'peek':
         return await cmdPeek(bus, cfg);
+      case 'ack':
+        return await cmdAck(bus, cfg, flags.all, positional.slice(1));
       case 'wait':
         return await cmdWait(bus, cfg, flags.timeout ?? 30000);
       case 'claim':
@@ -686,7 +695,9 @@ This repo has a message bus for AI agents. When working here:
   (active/idle agents, their statuses, recent activity).
 - Coordinate with other agents via \`send\`/\`wait\` (subjects: task, ack,
   done, question, status; reply on the sender's --thread).
-- Always check your inbox before reporting work done.
+- Always check your inbox before reporting work done. \`inbox\` consumes;
+  \`peek\` shows without consuming and \`agentcomm ack --all\` clears what you
+  have handled, so mail you read another way stops counting as unread.
 - Stuck? Declare it: \`agentcomm register --status "blocked: <what you
   need>"\` — other agents' digests will recruit help. If a digest shows
   someone else blocked and you KNOW the answer, send it without asking
@@ -1107,7 +1118,41 @@ async function cmdPeek(bus: Bus, cfg: ResolvedConfig): Promise<number> {
   const me = await resolveAgent(cfg);
   const messages = await bus.peek(me);
   await printMessages(messages, cfg, me);
+  // peek leaves the mail unread by design; say how to clear it once acted on,
+  // or the unread count (and the stop guard) never drops (issue #160).
+  if (!cfg.json && messages.length > 0) {
+    await writeOut(`— ${messages.length} still unread; clear what you have handled: agentcomm ack --all\n`);
+  }
   return 0;
+}
+
+/**
+ * Clear mail that was read some other way — `peek`, a digest, a delivery this
+ * process could not consume. Read and clear used to be the same operation, so
+ * an agent that had read and answered every message still faced a stop guard
+ * demanding it read them (issue #160).
+ */
+async function cmdAck(bus: Bus, cfg: ResolvedConfig, all: boolean, ids: string[]): Promise<number> {
+  const me = await resolveAgent(cfg);
+  if (!all && ids.length === 0) {
+    fail('ack requires message ids (from `peek`/`inbox --json`) or --all: agentcomm ack <id…> | agentcomm ack --all');
+  }
+  const result = await bus.ack(me, all ? 'all' : ids);
+  if (cfg.json) {
+    await writeOut(JSON.stringify({ agent: me, ...result }, null, 2) + '\n');
+    return result.unknown.length > 0 ? 1 : 0;
+  }
+  await writeOut(
+    [
+      `acked ${result.acked.length} message(s) for ${me}`,
+      ...(result.failed.length ? [`could not archive: ${result.failed.join(', ')} — still pending`] : []),
+      ...(result.unknown.length
+        ? [`not pending for ${me}: ${result.unknown.join(', ')} (already acked, or addressed to another alias)`]
+        : []),
+      '',
+    ].join('\n'),
+  );
+  return result.unknown.length > 0 ? 1 : 0;
 }
 
 async function cmdWait(bus: Bus, cfg: ResolvedConfig, timeoutMs: number): Promise<number> {

--- a/src/config.ts
+++ b/src/config.ts
@@ -46,6 +46,7 @@ export interface ParsedFlags {
   flush: boolean;
   check: boolean;
   uninstall: boolean;
+  all: boolean;
   events?: string;
   since?: string;
   _: string[]; // positional args
@@ -64,6 +65,7 @@ export function parseArgs(argv: string[]): ParsedFlags {
     version: false,
     check: false,
     uninstall: false,
+    all: false,
     _: [],
   };
   for (let i = 0; i < argv.length; i++) {
@@ -160,6 +162,9 @@ export function parseArgs(argv: string[]): ParsedFlags {
         break;
       case 'uninstall':
         flags.uninstall = true;
+        break;
+      case 'all':
+        flags.all = true;
         break;
       case 'events':
         flags.events = takeVal();

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -180,11 +180,38 @@ export async function runDaemon(uri: string): Promise<void> {
     });
   }
 
-  // warm mirror: full key set + bodies. On Snapshottable backends every poll
-  // is one round trip (bodies included); elsewhere the poll carries keys only
-  // and bodies fill lazily through the `get` passthrough — message blobs are
-  // immutable, and agent records (which mutate: heartbeats) are invalidated
-  // each poll so the next read refetches them.
+  // warm mirror: the full key set, plus the bodies worth holding. Message
+  // blobs are immutable, so a body already held is never re-read; agent
+  // records (which mutate: heartbeats) are refreshed every poll.
+  //
+  // What is NOT held warm is history (issue #167). A bus only grows, and
+  // re-reading every archived message and telemetry batch on every poll made
+  // the daemon's cost scale with all history instead of with what is hot —
+  // forever, on a store where nothing but the last few messages is live.
+  // Archives and events older than the window keep their KEY (so list, log,
+  // purge and channel discovery see the whole store, exactly as before) and
+  // their body fills on demand through the `get` passthrough.
+  const historyMs = Math.max(0, Number(process.env.AGENTCOMM_MIRROR_HISTORY_MS ?? 7 * 24 * 3600_000));
+  const HOT_PREFIXES = ['agents/', 'inbox/'];
+  /**
+   * ms timestamp encoded in an archive/event key, or null when it has none.
+   * Both layouts put a zero-padded, monotonic ms prefix on the filename:
+   * read/<recipient>/<ms>-<counter>_<id>.json and events/<ms>-<counter>_<id>.json.
+   */
+  const keyTime = (key: string): number | null => {
+    const m = /^0*(\d+)-/.exec(key.slice(key.lastIndexOf('/') + 1));
+    return m ? Number(m[1]) : null;
+  };
+  const withinWindow = (key: string): boolean => {
+    const ts = keyTime(key);
+    return ts === null || Date.now() - ts <= historyMs;
+  };
+  /** Should the mirror hold this key's body at all? */
+  const worthWarming = (key: string): boolean => HOT_PREFIXES.some((p) => key.startsWith(p)) || withinWindow(key);
+  /** Should THIS poll read it? Not if we already hold an immutable body. */
+  const needsRead = (key: string): boolean =>
+    key.startsWith('agents/') || (worthWarming(key) && !mirror.has(key));
+
   const mirror = new Map<string, Buffer>();
   let keys = new Set<string>();
 
@@ -237,23 +264,24 @@ export async function runDaemon(uri: string): Promise<void> {
 
   async function doPoll(): Promise<void> {
     const spooled = await snapshotSpool();
+    // Bodies this poll actually read (fresh agent records + keys we do not
+    // already hold), merged onto the ones already warm.
+    const fetched = new Map<string, Buffer>();
+    let next: Set<string>;
     if (isSnapshottable(backend)) {
-      const snap = await backend.snapshot('');
-      const present = new Set(snap.keys());
-      replaySpool(spooled, snap, present);
-      for (const k of snap.keys()) if (!present.has(k)) snap.delete(k);
-      mirror.clear();
-      for (const [k, v] of snap) mirror.set(k, v);
-      keys = present;
-      return;
+      const snap = await backend.snapshot('', { bodies: needsRead });
+      next = new Set(snap.keys);
+      for (const [k, v] of snap.bodies) fetched.set(k, v);
+    } else {
+      next = new Set(await backend.list(''));
     }
-    const bodies = new Map<string, Buffer>();
-    const next = new Set(await backend.list(''));
-    replaySpool(spooled, bodies, next);
+    replaySpool(spooled, fetched, next);
     for (const k of mirror.keys()) {
-      if (!next.has(k) || k.startsWith('agents/')) mirror.delete(k);
+      // drop what the store no longer has, what a fresher read supersedes,
+      // and history that has aged out of the warm window
+      if (!next.has(k) || k.startsWith('agents/') || !worthWarming(k)) mirror.delete(k);
     }
-    for (const [k, v] of bodies) if (next.has(k)) mirror.set(k, v);
+    for (const [k, v] of fetched) if (next.has(k)) mirror.set(k, v);
     keys = next;
   }
   // Coalesce: timer ticks, `refresh`, and post-claim polls that overlap a

--- a/src/hook-run.ts
+++ b/src/hook-run.ts
@@ -272,7 +272,8 @@ async function hookStopGuard(input: HookInput): Promise<void> {
       reason:
         `agentcomm delivery (working as intended — not an error): ${msgs.length} unread bus message(s) ` +
         `for ${alias} (from: ${from}). Read them with \`agentcomm inbox --json\`, act or tell the user why not, ` +
-        'then finish.',
+        'then finish. If you already read them another way (peek, a digest), clear them with ' +
+        '`agentcomm ack --all` — that is what this guard is counting.',
     }),
   );
 }

--- a/src/session.ts
+++ b/src/session.ts
@@ -181,3 +181,84 @@ export async function recordAlias(session: string, alias: string): Promise<strin
 function hash(seed: string): string {
   return createHash('sha1').update(seed).digest('hex').slice(0, 12);
 }
+
+// ── mailbox leases (issue #161) ─────────────────────────────────────────────
+
+/**
+ * A subagent inherits its parent's git identity and process tree, so it
+ * derives the parent's alias — and since reads consume, one `agentcomm inbox`
+ * from a subagent drains the mailbox its parent is waiting on. Identity stays
+ * per-session on purpose (a session IS a mailbox; see the sticky fingerprint
+ * above), so what is needed is not a different name but VISIBILITY: while a
+ * process is acting as an alias it leaves a lease behind, and anything
+ * destructive done to a leased mailbox by another live process says so.
+ *
+ * Leases are local files: the case they cover — two processes of one agent
+ * session on one machine — is exactly the local case.
+ */
+export interface Lease {
+  alias: string;
+  pid: number;
+  /** What that process is doing, for a message a human can act on. */
+  command: string;
+  since: string;
+}
+
+/** Leases older than this are ignored even if the pid is somehow still alive. */
+const LEASE_TTL_MS = 30 * 60_000;
+
+const leaseFile = (alias: string, pid: number): string => path.join(stateDir(), `lease-${alias}-${pid}.json`);
+
+const pidAlive = (pid: number): boolean => {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * Take a lease on `alias` for this process and return the OTHER live holders.
+ * Callers decide what to say about them — a consuming read on a mailbox
+ * another process is holding is worth a loud warning; a heartbeat is not.
+ */
+export async function leaseMailbox(alias: string, command: string): Promise<Lease[]> {
+  const others: Lease[] = [];
+  const dir = stateDir();
+  let names: string[] = [];
+  try {
+    names = await fs.readdir(dir);
+  } catch {
+    /* no state yet */
+  }
+  for (const name of names) {
+    if (!name.startsWith(`lease-${alias}-`) || !name.endsWith('.json')) continue;
+    const file = path.join(dir, name);
+    try {
+      const lease = JSON.parse(await fs.readFile(file, 'utf8')) as Lease;
+      const stale = Date.now() - Date.parse(lease.since) > LEASE_TTL_MS;
+      if (lease.pid === process.pid) continue;
+      if (stale || !pidAlive(lease.pid)) {
+        await fs.rm(file, { force: true }).catch(() => {});
+        continue;
+      }
+      if (lease.alias === alias) others.push(lease);
+    } catch {
+      await fs.rm(file, { force: true }).catch(() => {});
+    }
+  }
+  const mine: Lease = { alias, pid: process.pid, command, since: new Date().toISOString() };
+  try {
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(leaseFile(alias, process.pid), JSON.stringify(mine));
+  } catch {
+    /* a lease is advisory — never fail a command over it */
+  }
+  return others;
+}
+
+/** Drop this process's lease. Called when the command ends. */
+export async function releaseMailbox(alias: string): Promise<void> {
+  await fs.rm(leaseFile(alias, process.pid), { force: true }).catch(() => {});
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -73,8 +73,19 @@ export interface Claimable {
  * clock — the bus daemon uses this to warm its mirror in one round trip.
  */
 export interface Snapshottable {
-  /** All keys under `prefix` with their bodies, read at a single consistent point. */
-  snapshot(prefix: string): Promise<Map<string, Buffer>>;
+  /**
+   * Every key under `prefix` at a single consistent point, with the bodies
+   * `opts.bodies` selects (all of them when it is absent).
+   *
+   * The split matters because a bus's history only grows: re-reading every
+   * archived body on every poll makes the daemon cost scale with all history
+   * rather than with what is hot (issue #167). Keys are cheap to list, so
+   * callers still see the whole store and fetch a cold body on demand.
+   */
+  snapshot(
+    prefix: string,
+    opts?: { bodies?: (key: string) => boolean },
+  ): Promise<{ keys: string[]; bodies: Map<string, Buffer> }>;
 }
 
 /**

--- a/test/bus.test.ts
+++ b/test/bus.test.ts
@@ -348,3 +348,43 @@ describe('ack clears mail already read (issue #160)', () => {
     expect(await bus.peek('bob')).toHaveLength(1);
   });
 });
+
+/**
+ * `sent` has only ever meant QUEUED (issue #162). These cover the two facts
+ * that make "and someone read it" answerable: a per-recipient unread depth,
+ * and when each agent last consumed its mailbox.
+ */
+describe('delivery visibility (issue #162)', () => {
+  it('counts unread per recipient, including mailboxes nobody registered', async () => {
+    const bus = new Bus(new LocalBackend(await mkTmp()));
+    await bus.register('bob');
+    await bus.send({ from: 'alice', to: 'bob', body: '1' });
+    await bus.send({ from: 'alice', to: 'bob', body: '2' });
+    await bus.send({ from: 'alice', to: 'ghost', body: 'nobody home' });
+
+    expect(await bus.unreadCounts()).toEqual({ bob: 2, ghost: 1 });
+    expect(await bus.unread('bob')).toBe(2);
+    expect(await bus.unread('nobody')).toBe(0);
+  });
+
+  it('markRead stamps lastRead, and a heartbeat preserves it', async () => {
+    const bus = new Bus(new LocalBackend(await mkTmp()));
+    await bus.register('bob', 'sess');
+    expect((await bus.agents())[0]!.lastRead).toBeUndefined();
+
+    await bus.markRead('bob');
+    const read = (await bus.agents())[0]!.lastRead;
+    expect(read).toBeTruthy();
+
+    await bus.register('bob', 'sess'); // heartbeat must not erase the read stamp
+    expect((await bus.agents())[0]!.lastRead).toBe(read);
+  });
+
+  it('markRead never conjures a registration — a one-off read leaves no ghost', async () => {
+    const bus = new Bus(new LocalBackend(await mkTmp()));
+    await bus.markRead('walk-in');
+    // registrations are never purged; a `inbox --as someone` must not create
+    // a permanent roster entry
+    expect(await bus.agents()).toEqual([]);
+  });
+});

--- a/test/bus.test.ts
+++ b/test/bus.test.ts
@@ -306,3 +306,45 @@ describe('archive batches when the backend can (issue #159)', () => {
     expect((await inner.list('inbox/bob/')).length).toBe(0);
   });
 });
+
+/**
+ * Read and clear were the same operation (issue #160): `peek` shows without
+ * consuming, `inbox` consumes what it shows, and nothing cleared mail read
+ * any other way — so an agent that had read and answered every message still
+ * showed N unread forever.
+ */
+describe('ack clears mail already read (issue #160)', () => {
+  it('acks by id without re-fetching bodies, and reports ids that are not pending', async () => {
+    const backend = new LocalBackend(await mkTmp());
+    const bus = new Bus(backend);
+    const one = await bus.send({ from: 'alice', to: 'bob', body: 'one' });
+    const two = await bus.send({ from: 'alice', to: 'bob', body: 'two' });
+    await bus.send({ from: 'alice', to: 'bob', body: 'three' });
+
+    expect(await bus.peek('bob')).toHaveLength(3); // read, non-destructively
+
+    const acked = await bus.ack('bob', [one.id, two.id, 'not-a-real-id']);
+    expect(acked.acked.sort()).toEqual([one.id, two.id].sort());
+    expect(acked.unknown).toEqual(['not-a-real-id']);
+    expect(acked.failed).toEqual([]);
+
+    expect((await bus.peek('bob')).map((m) => m.body)).toEqual(['three']);
+    expect((await backend.list('read/bob/')).length).toBe(2); // archived, not deleted
+  });
+
+  it('--all clears the whole mailbox; acking an empty one is a no-op', async () => {
+    const bus = new Bus(new LocalBackend(await mkTmp()));
+    for (const body of ['a', 'b']) await bus.send({ from: 'alice', to: 'bob', body });
+    expect((await bus.ack('bob', 'all')).acked).toHaveLength(2);
+    expect(await bus.peek('bob')).toHaveLength(0);
+    expect(await bus.ack('bob', 'all')).toEqual({ acked: [], unknown: [], failed: [] });
+  });
+
+  it('one agent cannot ack another agent mailbox message', async () => {
+    const bus = new Bus(new LocalBackend(await mkTmp()));
+    const mine = await bus.send({ from: 'alice', to: 'bob', body: 'for bob' });
+    const result = await bus.ack('carol', [mine.id]);
+    expect(result.unknown).toEqual([mine.id]);
+    expect(await bus.peek('bob')).toHaveLength(1);
+  });
+});

--- a/test/cli.e2e.test.ts
+++ b/test/cli.e2e.test.ts
@@ -74,6 +74,36 @@ describe('CLI e2e (sqlite backend)', () => {
     expect(JSON.parse(empty.stdout)).toEqual([]);
   });
 
+  it('peek → ack clears the unread count without a consuming read (issue #160)', async () => {
+    const db = `sqlite://${path.join(await mkTmp(), 'bus.db')}`;
+    const first = JSON.parse((await run(['send', 'bob', 'one', '--as', 'alice', '--backend', db, '--json'])).stdout) as {
+      id: string;
+    };
+    await run(['send', 'bob', 'two', '--as', 'alice', '--backend', db, '--json']);
+
+    // read non-destructively — the human view says how to clear it
+    const peeked = await run(['peek', '--as', 'bob', '--backend', db]);
+    expect(peeked.stdout).toMatch(/2 still unread; clear what you have handled: agentcomm ack --all/);
+
+    const one = await run(['ack', first.id, '--as', 'bob', '--backend', db, '--json']);
+    expect(one.code).toBe(0);
+    expect(JSON.parse(one.stdout)).toMatchObject({ agent: 'bob', acked: [first.id], unknown: [] });
+    expect((JSON.parse((await run(['peek', '--as', 'bob', '--backend', db, '--json'])).stdout) as unknown[]).length).toBe(1);
+
+    // an id that is not pending is an explicit non-zero, not a silent success
+    const bogus = await run(['ack', 'deadbeef', '--as', 'bob', '--backend', db]);
+    expect(bogus.code).toBe(1);
+    expect(bogus.stdout).toMatch(/not pending for bob: deadbeef/);
+
+    const all = await run(['ack', '--all', '--as', 'bob', '--backend', db]);
+    expect(all.stdout).toMatch(/acked 1 message\(s\) for bob/);
+    expect(JSON.parse((await run(['peek', '--as', 'bob', '--backend', db, '--json'])).stdout)).toEqual([]);
+
+    const bare = await run(['ack', '--as', 'bob', '--backend', db]);
+    expect(bare.code).toBe(1);
+    expect(bare.stderr).toMatch(/ack requires message ids/);
+  });
+
   it('network reports active/idle agents, statuses, and recent activity', async () => {
     const db = `sqlite://${path.join(await mkTmp(), 'bus.db')}`;
     const env = { ...process.env, AGENTCOMM_SESSION: 'net-test', AGENTCOMM_NO_GIT_PROBE: '1' };

--- a/test/cli.e2e.test.ts
+++ b/test/cli.e2e.test.ts
@@ -104,6 +104,45 @@ describe('CLI e2e (sqlite backend)', () => {
     expect(bare.stderr).toMatch(/ack requires message ids/);
   });
 
+  it('send flags a recipient that is not reading; a consuming read clears the flag (issue #162)', async () => {
+    const db = `sqlite://${path.join(await mkTmp(), 'bus.db')}`;
+
+    // never registered: nothing is known to be reading that mailbox
+    const cold = await run(['send', 'ghost', 'anyone there?', '--as', 'alice', '--backend', db]);
+    expect(cold.stdout).toMatch(/warning — ghost has never registered on this bus/);
+
+    await run(['register', '--as', 'bob', '--backend', db]);
+    // first message to a registered agent is not suspicious on its own
+    const first = await run(['send', 'bob', 'one', '--as', 'alice', '--backend', db]);
+    expect(first.stdout).not.toMatch(/warning/);
+
+    // mail stacking up with no consuming read ever = worth saying
+    const second = await run(['send', 'bob', 'two', '--as', 'alice', '--backend', db]);
+    expect(second.stdout).toMatch(/warning — bob has 2 unread and has never consumed its mailbox/);
+
+    const roster = JSON.parse((await run(['agents', '--backend', db, '--json'])).stdout) as {
+      name: string;
+      unread: number;
+      lastRead?: string;
+    }[];
+    expect(roster.find((a) => a.name === 'bob')).toMatchObject({ unread: 2 });
+    expect(roster.find((a) => a.name === 'bob')!.lastRead).toBeUndefined();
+
+    // bob reads: the warning stops and the roster records the read
+    await run(['inbox', '--as', 'bob', '--backend', db, '--json']);
+    const after = await run(['send', 'bob', 'three', '--as', 'alice', '--backend', db]);
+    expect(after.stdout).not.toMatch(/warning/);
+    const read = (JSON.parse((await run(['agents', '--backend', db, '--json'])).stdout) as { name: string; lastRead?: string }[])
+      .find((a) => a.name === 'bob')!.lastRead;
+    expect(read).toBeTruthy();
+
+    // and network surfaces mail queued for a name nobody registered
+    const net = JSON.parse((await run(['network', '--backend', db, '--json'])).stdout) as {
+      unclaimed: { name: string; unread: number }[];
+    };
+    expect(net.unclaimed).toEqual([{ name: 'ghost', unread: 1 }]);
+  });
+
   it('network reports active/idle agents, statuses, and recent activity', async () => {
     const db = `sqlite://${path.join(await mkTmp(), 'bus.db')}`;
     const env = { ...process.env, AGENTCOMM_SESSION: 'net-test', AGENTCOMM_NO_GIT_PROBE: '1' };

--- a/test/daemon.e2e.test.ts
+++ b/test/daemon.e2e.test.ts
@@ -313,6 +313,33 @@ describe('bus daemon: same semantics, immediate answers', () => {
     expect(archived).toHaveLength(3);
   });
 
+  it('keeps only recent history warm, but still serves the old (issue #167)', async () => {
+    const dir = await mkTmp();
+    // an archived message from long ago, and a fresh one — both on the store
+    const archive = path.join(dir, '.bus', 'read', 'alpha');
+    await fs.mkdir(archive, { recursive: true });
+    const oldTs = String(Date.now() - 30 * 24 * 3600_000).padStart(15, '0');
+    await fs.writeFile(
+      path.join(archive, `${oldTs}-000000_ancient.json`),
+      JSON.stringify({ id: 'ancient', from: 'beta', to: 'alpha', body: 'from a month ago', ts: new Date(0).toISOString() }),
+    );
+
+    const WINDOW = { AGENTCOMM_MIRROR_HISTORY_MS: String(7 * 24 * 3600_000) };
+    await run(['register', '--as', 'alpha', '--daemon'], dir, WINDOW);
+    await run(['send', 'alpha', 'today', '--as', 'beta', '--daemon', '--sync'], dir, WINDOW);
+
+    // the aged-out archive is still a first-class key: log finds it and reads
+    // its body through the passthrough, exactly as if it were warm
+    const log = await run(['log', '--limit', '10', '--daemon', '--json'], dir, WINDOW);
+    const bodies = (JSON.parse(log.stdout) as { body: string }[]).map((m) => m.body);
+    expect(bodies).toContain('from a month ago');
+    expect(bodies).toContain('today');
+
+    // and purge still sees it (list is unaffected by what the mirror holds)
+    const purge = await run(['purge', '--older-than', '14d', '--dry-run', '--daemon', '--json'], dir, WINDOW);
+    expect((JSON.parse(purge.stdout) as { count: number }).count).toBe(1);
+  });
+
   it('outbox survives a daemon crash: a fresh daemon delivers the leftovers', async () => {
     const dir = await mkTmp();
     const FROZEN = { AGENTCOMM_FLUSH_MS: '600000' };

--- a/test/git.e2e.test.ts
+++ b/test/git.e2e.test.ts
@@ -77,17 +77,36 @@ describe('GitBackend (local bare remotes — same code path as any host)', () =>
     const { uri, cache } = await bareRemote();
     const b = await open(uri, cache);
 
-    expect((await b.snapshot('')).size).toBe(0); // branch not born yet
+    expect((await b.snapshot('')).keys).toEqual([]); // branch not born yet
 
     await b.put('inbox/a/001.json', Buffer.from('one'));
     await b.put('inbox/b/001.json', Buffer.from('two'));
     await b.put('agents/a.json', Buffer.from('{"alias":"a"}'));
 
     const all = await b.snapshot('');
-    expect([...all.keys()].sort()).toEqual(['agents/a.json', 'inbox/a/001.json', 'inbox/b/001.json']);
-    for (const [k, v] of all) expect(v.equals(await b.get(k))).toBe(true); // bodies match per-key reads
+    expect([...all.keys].sort()).toEqual(['agents/a.json', 'inbox/a/001.json', 'inbox/b/001.json']);
+    for (const [k, v] of all.bodies) expect(v.equals(await b.get(k))).toBe(true); // bodies match per-key reads
 
-    expect([...(await b.snapshot('inbox/a/')).keys()]).toEqual(['inbox/a/001.json']);
+    expect((await b.snapshot('inbox/a/')).keys).toEqual(['inbox/a/001.json']);
+  }, 60000);
+
+  it('snapshot reads only the bodies asked for, but reports every key (issue #167)', async () => {
+    const { uri, cache } = await bareRemote();
+    const b = await open(uri, cache);
+    await b.put('agents/a.json', Buffer.from('{"alias":"a"}'));
+    await b.put('read/a/000000000000001-000000_old.json', Buffer.from('ancient history'));
+    await b.put('inbox/a/000000000000002-000000_new.json', Buffer.from('live mail'));
+
+    const warm = await b.snapshot('', { bodies: (key) => !key.startsWith('read/') });
+    // the archive still EXISTS as far as list/log/purge are concerned...
+    expect(warm.keys).toContain('read/a/000000000000001-000000_old.json');
+    // ...its body just was not read
+    expect([...warm.bodies.keys()].sort()).toEqual([
+      'agents/a.json',
+      'inbox/a/000000000000002-000000_new.json',
+    ]);
+    // and it is still one `get` away
+    expect((await b.get('read/a/000000000000001-000000_old.json')).toString()).toBe('ancient history');
   }, 60000);
 
   it('move is ATOMIC — one commit relocates the key', async () => {

--- a/test/mailbox-lease.e2e.test.ts
+++ b/test/mailbox-lease.e2e.test.ts
@@ -1,0 +1,123 @@
+/**
+ * e2e for mailbox leases (issue #161).
+ *
+ * A subagent inherits its parent's git identity and process tree, so it
+ * derives the parent's alias — and since reads consume, one `agentcomm inbox`
+ * from a subagent drains the mailbox its parent is waiting on. The alias
+ * stays per-session on purpose; what these cover is that sharing one is no
+ * longer silent.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { promises as fs } from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { createRequire } from 'node:module';
+import { spawn } from 'node:child_process';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const cli = path.join(here, '..', 'src', 'cli.ts');
+const tsx = pathToFileURL(createRequire(import.meta.url).resolve('tsx')).href;
+
+const tmpRoots: string[] = [];
+async function mkTmp(): Promise<string> {
+  const dir = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), 'agentcomm-lease-')));
+  tmpRoots.push(dir);
+  return dir;
+}
+afterEach(async () => {
+  for (const dir of tmpRoots.splice(0)) await fs.rm(dir, { recursive: true, force: true });
+});
+
+interface Ctx {
+  dir: string;
+  state: string;
+}
+
+function spawnCli(args: string[], ctx: Ctx): ReturnType<typeof spawn> {
+  return spawn(process.execPath, ['--import', tsx, cli, ...args], {
+    stdio: ['ignore', 'pipe', 'pipe'],
+    cwd: ctx.dir,
+    env: {
+      PATH: process.env.PATH,
+      HOME: process.env.HOME,
+      AGENTCOMM_BACKEND: `file://${path.join(ctx.dir, '.bus')}`,
+      AGENTCOMM_NO_GIT_PROBE: '1',
+      AGENTCOMM_SESSION: 'lease-test',
+      AGENTCOMM_STATE_DIR: ctx.state,
+    },
+  });
+}
+
+function run(args: string[], ctx: Ctx): Promise<{ code: number; stdout: string; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    const child = spawnCli(args, ctx);
+    let stdout = '';
+    let stderr = '';
+    child.stdout!.on('data', (d) => (stdout += d.toString()));
+    child.stderr!.on('data', (d) => (stderr += d.toString()));
+    child.on('error', reject);
+    child.on('exit', (code) => resolve({ code: code ?? -1, stdout, stderr }));
+  });
+}
+
+async function ctx(): Promise<Ctx> {
+  return { dir: await mkTmp(), state: await mkTmp() };
+}
+
+describe('mailbox leases: sharing an alias stops being silent (issue #161)', () => {
+  it('a consuming read warns while another live process holds the same alias', async () => {
+    const c = await ctx();
+    // the "parent": a listener blocked on its own mailbox, holding it
+    const listener = spawnCli(['wait', '--as', 'worker', '--timeout', '8000'], c);
+    await new Promise((r) => setTimeout(r, 1200)); // let it take the lease
+
+    // the "subagent": same alias, consuming read — the mail it drains would
+    // have been the listener's
+    const drain = await run(['inbox', '--as', 'worker', '--json'], c);
+    expect(drain.stderr).toMatch(/WARNING — another live process of this session is acting as "worker"/);
+    expect(drain.stderr).toMatch(/agentcomm wait/); // says what that process is doing
+    expect(drain.stderr).toMatch(/--as worker-<role>/); // and the remedy
+
+    listener.kill('SIGKILL');
+  });
+
+  it('says nothing when nobody else holds the alias, and cleans up after itself', async () => {
+    const c = await ctx();
+    await run(['send', 'solo', 'hello', '--as', 'boss'], c);
+
+    const first = await run(['inbox', '--as', 'solo'], c);
+    expect(first.stderr).not.toMatch(/WARNING/);
+    // the lease is released at exit — the NEXT command must not see a ghost
+    const second = await run(['inbox', '--as', 'solo'], c);
+    expect(second.stderr).not.toMatch(/WARNING/);
+    expect((await fs.readdir(c.state)).filter((f) => f.startsWith('lease-'))).toEqual([]);
+  });
+
+  it('a status write onto an alias another process is holding says whose line it replaces', async () => {
+    const c = await ctx();
+    const listener = spawnCli(['wait', '--as', 'shared', '--timeout', '8000'], c);
+    await new Promise((r) => setTimeout(r, 1200));
+
+    const status = await run(['register', '--as', 'shared', '--status', 'subagent work'], c);
+    expect(status.stderr).toMatch(/WARNING — another live process of this session is acting as "shared"/);
+    expect(status.stderr).toMatch(/replaces its line on the shared roster/);
+
+    // a plain heartbeat is not a claim on the roster — no warning
+    const heartbeat = await run(['register', '--as', 'shared'], c);
+    expect(heartbeat.stderr).not.toMatch(/WARNING/);
+
+    listener.kill('SIGKILL');
+  });
+
+  it('a lease left by a dead process is ignored, not inherited', async () => {
+    const c = await ctx();
+    await fs.writeFile(
+      path.join(c.state, 'lease-ghost-999999.json'),
+      JSON.stringify({ alias: 'ghost', pid: 999999, command: 'wait', since: new Date().toISOString() }),
+    );
+    const r = await run(['inbox', '--as', 'ghost'], c);
+    expect(r.stderr).not.toMatch(/WARNING/);
+    expect(await fs.readdir(c.state)).not.toContain('lease-ghost-999999.json');
+  });
+});


### PR DESCRIPTION
Closes #162. Top of the stack (#169 → #168 → #166), rebases to `main` as those merge.

Every `send` reported `sent <id> → <recipient>`, including the ones the recipient could never retrieve: 25 sends reported success in one session while delivery was degraded, and no sender ever got a hint. `sent` has only ever meant **queued**.

## What changed

- **`src/bus.ts`** — `lastRead` on the agent record, stamped by `markRead` when an agent consumes its mailbox (`inbox`, `ack`). Only an **existing** registration is stamped: registrations are never purged, so a one-off `inbox --as someone` must not leave a permanent ghost on the roster. Plus `unreadCounts()` / `unread(name)` — per-recipient depth from keys alone, one list, no bodies.
- **`src/cli.ts`** — `send` warns when the evidence says nobody is picking the mail up: the recipient never registered under that name, or has unread stacking up with no consuming read within `AGENTCOMM_STALE_READ_MS` (6h). The warning rides `--json` too. `agents` gains unread depth and last-read age; `network` shows the same, plus **unread for nobody** — mail queued to names nobody ever registered, which a roster built from registrations alone cannot show at all.

## Tests

`test/bus.test.ts`: unread counts (including unregistered mailboxes), `lastRead` stamped and preserved across heartbeats, and no registration conjured by a read. `test/cli.e2e.test.ts`: an unregistered recipient warns on the first send, a registered one only once mail stacks up unread, the warning stops after a real read, and `network --json` lists the unclaimed mailbox.