### PR TITLE
release prep: 0.21.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yonidavidson/agentcomm",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@yonidavidson/agentcomm",
-      "version": "0.20.0",
+      "version": "0.21.0",
       "license": "MIT",
       "bin": {
         "agentcomm": "dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yonidavidson/agentcomm",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "A tiny mailbox/message bus for AI agents that shell out to one CLI. Pluggable storage backends behind a single Backend interface.",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
Version bump only — `main` already carries the tree this releases. `release-cut.yml` runs after this merges.

Ships the fixes from a field report of an 18h multi-agent orchestration session, where the bus worked as a notification layer but not as a delivery layer:

- **#157** the session alias no longer drifts mid-session — a wrapper process used to move the agent to a different, empty mailbox while mail kept arriving at the old one
- **#158** mail is delivered before it is consumed; an interrupted read costs a duplicate, never a message
- **#159** consuming a mailbox is one round trip instead of one per message (`inbox` used to time out where `peek` was instant)
- **#160** new `agentcomm ack <id…> | --all` clears mail read some other way, so the unread count can actually drop
- **#161** two live processes on one mailbox (a subagent and its parent) announce themselves before one drains the other
- **#162** `send` reports when a recipient is not reading; `agents`/`network` carry unread depth and last-read age
- **#167** the daemon keeps a week of history warm instead of the whole archive, every poll

**SDK note (pre-1.0, so a minor):** `Snapshottable.snapshot` now takes a body filter and returns `{keys, bodies}`; `Batchable` (`moveMany`) is a new optional capability. Both are optional interfaces only backends implement.